### PR TITLE
Remove the bin/ exclusion from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.pydevproject
 .project
 .metadata
-bin/
 tmp/
 *.tmp
 *.bak


### PR DESCRIPTION
As .gitignore applies to all folders, ignoring bin folders means that retroarch and mod_hakchi are missing their bin folders, which stops us from being able to build the project, and from using the retroarch mod.