### PR TITLE
Create snes.xml game database

### DIFF
--- a/data/snes.xml
+++ b/data/snes.xml
@@ -2,7 +2,7 @@
 <Data>
   <Game>
     <name>2020 Super Baseball</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>0d77933e</crc>
     <date>1993-03-12</date>
@@ -156,7 +156,7 @@
   </Game>
   <Game>
     <name>Adventures of Dr. Franken, The</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>cfab3bba</crc>
     <date>1993-12-01</date>
@@ -178,7 +178,7 @@
   </Game>
   <Game>
     <name>Adventures of Rocky and Bullwinkle and Friends, The</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>dc8f5734</crc>
     <date>1993-06-01</date>
@@ -201,7 +201,7 @@
   <Game>
     <name>Aero Fighters</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>f194d00a</crc>
     <date>1994-01-01</date>
     <publisher>Tecmo</publisher>
@@ -233,7 +233,7 @@
   </Game>
   <Game>
     <name>Aerobiz</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>54302a46</crc>
     <date>1993-02-01</date>
@@ -244,7 +244,7 @@
   </Game>
   <Game>
     <name>Aerobiz Supersonic</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>efafab12</crc>
     <date>1994-08-01</date>
@@ -267,7 +267,7 @@
   <Game>
     <name>Al Unser Jr.'s Road to the Top</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>d0550624</crc>
     <date>1994-11-01</date>
     <publisher>Software Toolworks</publisher>
@@ -310,7 +310,7 @@
   </Game>
   <Game>
     <name>American Gladiators</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>76b151fd</crc>
     <date>1993-04-13</date>
@@ -354,24 +354,24 @@
   </Game>
   <Game>
     <name>Arcade's Greatest Hits</name>
-    <players/>
-    <simultaneous/>
-    <crc>471b12b0</crc>
-    <date>1996</date>
-    <publisher>Midway</publisher>
-    <region>USA</region>
-    <cover/>
-  </Game>
-  <Game>
-    <name>Arcade's Greatest Hits - The Atari Collection 1</name>
     <players>2</players>
     <simultaneous>0</simultaneous>
-    <crc>02394f36</crc>
+    <crc>471b12b0</crc>
     <date>1997-08-30</date>
     <publisher>Midway</publisher>
     <region>USA</region>
     <cover>http://thegamesdb.net/banners/boxart/original/front/1568-1.jpg</cover>
     <api_id>1568</api_id>
+  </Game>
+  <Game>
+    <name>Arcade's Greatest Hits - The Atari Collection 1</name>
+    <players/>
+    <simultaneous/>
+    <crc>02394f36</crc>
+    <date>1997</date>
+    <publisher>Midway</publisher>
+    <region>USA</region>
+    <cover/>
   </Game>
   <Game>
     <name>Arcana</name>
@@ -420,7 +420,7 @@
   <Game>
     <name>Art of Fighting</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>9fa74067</crc>
     <date>1992-09-24</date>
     <publisher>Takara</publisher>
@@ -486,7 +486,7 @@
   <Game>
     <name>Barbie Super Model</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>3b73610e</crc>
     <date>1993-01-01</date>
     <publisher>Hi-Tech Expressions, Inc.</publisher>
@@ -574,7 +574,7 @@
   <Game>
     <name>Battle Blaze</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>d933bd8d</crc>
     <date>1992-10-07</date>
     <publisher>Sammy</publisher>
@@ -596,7 +596,7 @@
   <Game>
     <name>Battle Clash</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>59c00310</crc>
     <date>1993-06-21</date>
     <publisher>Nintendo</publisher>
@@ -607,7 +607,7 @@
   <Game>
     <name>Battle Grand Prix</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>190ff436</crc>
     <date>1992-03-27</date>
     <publisher>Hudson Soft</publisher>
@@ -618,7 +618,7 @@
   <Game>
     <name>Battletoads &amp; Double Dragon</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>8b18ac01</crc>
     <date>1993-10-01</date>
     <publisher>Tradewest</publisher>
@@ -640,7 +640,7 @@
   <Game>
     <name>Bazooka Blitzkrieg</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>49c187f3</crc>
     <date>1992-12-31</date>
     <publisher>Bandai</publisher>
@@ -673,7 +673,7 @@
   <Game>
     <name>Bebe's Kids</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>bda2e412</crc>
     <date>1994-04-01</date>
     <publisher>Motown Games</publisher>
@@ -728,7 +728,7 @@
   <Game>
     <name>Bill Laimbeer's Combat Basketball</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>468d8cdd</crc>
     <date>1991-11-01</date>
     <publisher>Hudson Soft</publisher>
@@ -739,7 +739,7 @@
   <Game>
     <name>Bill Walsh College Football</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>25391c9f</crc>
     <date>1994-01-01</date>
     <publisher>Electronic Arts, Inc.</publisher>
@@ -783,7 +783,7 @@
   <Game>
     <name>Blues Brothers, The</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>82b97464</crc>
     <date>1993-03-26</date>
     <publisher>Titus Software</publisher>
@@ -826,7 +826,7 @@
   </Game>
   <Game>
     <name>Boxing Legends of the Ring</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>c0b632c0</crc>
     <date>1994-11-01</date>
@@ -860,7 +860,7 @@
   <Game>
     <name>Bram Stoker's Dracula</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>5cece690</crc>
     <date>1993-09-01</date>
     <publisher>Sony Imagesoft</publisher>
@@ -882,7 +882,7 @@
   <Game>
     <name>Brawl Brothers</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>e822065c</crc>
     <date>1993-04-15</date>
     <publisher>Jaleco</publisher>
@@ -937,7 +937,7 @@
   <Game>
     <name>Brett Hull Hockey</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>fbe35998</crc>
     <date>1994-01-01</date>
     <publisher>Accolade</publisher>
@@ -959,7 +959,7 @@
   <Game>
     <name>Brunswick World Tournament of Champions</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>52e4dc92</crc>
     <date>1997-08-01</date>
     <publisher>Black Pearl</publisher>
@@ -970,7 +970,7 @@
   <Game>
     <name>Brutal - Paws of Fury</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>8fe49f80</crc>
     <date>1994-12-01</date>
     <publisher>Kemco</publisher>
@@ -992,7 +992,7 @@
   <Game>
     <name>Bubsy in Claws Encounters of the Furred Kind</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>444a52c1</crc>
     <date>1993-01-01</date>
     <publisher>Accolade</publisher>
@@ -1036,7 +1036,7 @@
   <Game>
     <name>Cacoma Knight in Bizyland</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>ba921443</crc>
     <date>1993-10-07</date>
     <publisher>SETA Corporation</publisher>
@@ -1079,7 +1079,7 @@
   </Game>
   <Game>
     <name>Cannondale Cup</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>b95fe0a0</crc>
     <date>1994-01-01</date>
@@ -1091,7 +1091,7 @@
   <Game>
     <name>Capcom's MVP Football</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>bd0a0c0e</crc>
     <date>1992-01-01</date>
     <publisher>Capcom</publisher>
@@ -1102,7 +1102,7 @@
   <Game>
     <name>Capcom's Soccer Shootout</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>ee314ae5</crc>
     <date>1994-05-01</date>
     <publisher>Capcom</publisher>
@@ -1112,7 +1112,7 @@
   </Game>
   <Game>
     <name>Captain America and the Avengers</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>1</simultaneous>
     <crc>456ab5c8</crc>
     <date>1993-09-07</date>
@@ -1123,7 +1123,7 @@
   </Game>
   <Game>
     <name>Captain Commando</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>1</simultaneous>
     <crc>81db73c7</crc>
     <date>1991-11-24</date>
@@ -1135,7 +1135,7 @@
   <Game>
     <name>Captain Novolin</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>9fd460a4</crc>
     <date>1992-11-02</date>
     <publisher>Raya Systems</publisher>
@@ -1157,7 +1157,7 @@
   <Game>
     <name>Casper</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>a3b745bc</crc>
     <date>1996-01-01</date>
     <publisher>Natsume, Inc.</publisher>
@@ -1179,7 +1179,7 @@
   <Game>
     <name>Champions - World Class Soccer</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>bcd59d08</crc>
     <date>1994-01-01</date>
     <publisher>Acclaim Entertainment, Inc.</publisher>
@@ -1189,8 +1189,8 @@
   </Game>
   <Game>
     <name>Championship Pool</name>
-    <players>4+</players>
-    <simultaneous/>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
     <crc>98ef8414</crc>
     <date>1993-01-01</date>
     <publisher>Mindscape, Inc.</publisher>
@@ -1233,7 +1233,7 @@
   </Game>
   <Game>
     <name>Chessmaster, The</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>bc671e15</crc>
     <date>1991-09-01</date>
@@ -1245,7 +1245,7 @@
   <Game>
     <name>Chester Cheetah - Too Cool to Fool</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>552bf16a</crc>
     <date>1992-01-01</date>
     <publisher>Kaneko</publisher>
@@ -1311,7 +1311,7 @@
   <Game>
     <name>Clay Fighter</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>c814e3c2</crc>
     <date>1993-11-01</date>
     <publisher>Interplay</publisher>
@@ -1322,7 +1322,7 @@
   <Game>
     <name>Clay Fighter - Tournament Edition</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>b360f7af</crc>
     <date>1994-05-01</date>
     <publisher>Visual Concepts Entertainment, Inc</publisher>
@@ -1332,18 +1332,19 @@
   </Game>
   <Game>
     <name>Clay Fighter 2 - Judgment Clay</name>
-    <players/>
-    <simultaneous/>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
     <crc>20b5c364</crc>
-    <date>1994</date>
+    <date>1995-01-01</date>
     <publisher>Interplay</publisher>
     <region>USA</region>
-    <cover/>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2046-1.jpg</cover>
+    <api_id>2046</api_id>
   </Game>
   <Game>
     <name>Claymates</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>7ad5ccac</crc>
     <date>1993-11-20</date>
     <publisher>Interplay</publisher>
@@ -1353,8 +1354,8 @@
   </Game>
   <Game>
     <name>Cliffhanger</name>
-    <players/>
-    <simultaneous/>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
     <crc>12f8a26c</crc>
     <date>1993-11-01</date>
     <publisher>Sony</publisher>
@@ -1375,7 +1376,7 @@
   </Game>
   <Game>
     <name>College Football USA '97 - The Road to New Orleans</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>a27940c1</crc>
     <date>1996-01-01</date>
@@ -1387,7 +1388,7 @@
   <Game>
     <name>College Slam</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>ce842c6d</crc>
     <date>1996-01-01</date>
     <publisher>Acclaim</publisher>
@@ -1397,7 +1398,7 @@
   </Game>
   <Game>
     <name>Combatribes, The</name>
-    <players>3</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>9304044a</crc>
     <date>1990-06-01</date>
@@ -1409,7 +1410,7 @@
   <Game>
     <name>Congo's Caper</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>8a24fba8</crc>
     <date>1992-12-18</date>
     <publisher>Data East</publisher>
@@ -1442,7 +1443,7 @@
   <Game>
     <name>Cool World</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>0730c37c</crc>
     <date>1992-01-01</date>
     <publisher>Ocean Software</publisher>
@@ -1453,7 +1454,7 @@
   <Game>
     <name>Cutthroat Island</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>19ea457b</crc>
     <date>1995-10-07</date>
     <publisher>Acclaim Entertainment</publisher>
@@ -1464,7 +1465,7 @@
   <Game>
     <name>Cyber Spin</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>44018650</crc>
     <date>1992-03-19</date>
     <publisher>Takuyo</publisher>
@@ -1508,7 +1509,7 @@
   <Game>
     <name>Darius Twin</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>c5341764</crc>
     <date>1991-03-29</date>
     <publisher>Taito</publisher>
@@ -1519,7 +1520,7 @@
   <Game>
     <name>David Crane's Amazing Tennis</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>caad18dc</crc>
     <date>1992-10-07</date>
     <publisher>Absolute Entertainment</publisher>
@@ -1530,7 +1531,7 @@
   <Game>
     <name>Daze Before Christmas</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>59909eb5</crc>
     <date>1994-10-07</date>
     <publisher>Sunsoft</publisher>
@@ -1540,7 +1541,7 @@
   </Game>
   <Game>
     <name>Death and Return of Superman, The</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>a567957c</crc>
     <date>1995-01-01</date>
@@ -1552,7 +1553,7 @@
   <Game>
     <name>Demolition Man</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>8afe2f91</crc>
     <date>1995-03-01</date>
     <publisher>Acclaim, Virgin Interactive</publisher>
@@ -1574,7 +1575,7 @@
   <Game>
     <name>Dennis the Menace</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>8ee7faa5</crc>
     <date>1993-12-01</date>
     <publisher>Ocean Software</publisher>
@@ -1596,7 +1597,7 @@
   <Game>
     <name>Dig &amp; Spike Volleyball</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>954340f8</crc>
     <date>1993-01-01</date>
     <publisher>Hudson Soft</publisher>
@@ -1629,7 +1630,7 @@
   <Game>
     <name>Dirt Racer</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>0354f4b1</crc>
     <date>1995-01-01</date>
     <publisher>Elite</publisher>
@@ -1640,7 +1641,7 @@
   <Game>
     <name>Dirt Trax FX</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>61a86c7f</crc>
     <date>1995-06-01</date>
     <publisher>Acclaim Entertainment</publisher>
@@ -1717,7 +1718,7 @@
   <Game>
     <name>Doomsday Warrior</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>ceeb7c32</crc>
     <date>1992-01-01</date>
     <publisher>Renovation</publisher>
@@ -1738,7 +1739,7 @@
   </Game>
   <Game>
     <name>Dragon - The Bruce Lee Story</name>
-    <players>3</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>407c5c24</crc>
     <date>1995-07-05</date>
@@ -1750,7 +1751,7 @@
   <Game>
     <name>Dragon View</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>ab893412</crc>
     <date>1994-08-26</date>
     <publisher>KEMCO</publisher>
@@ -1793,7 +1794,7 @@
   </Game>
   <Game>
     <name>Duel, The - Test Drive II</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>ba093e24</crc>
     <date>1992-12-01</date>
@@ -1893,7 +1894,7 @@
   <Game>
     <name>Emmitt Smith Football</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>09c3c0ef</crc>
     <date>1995-01-01</date>
     <publisher>JVC</publisher>
@@ -1915,7 +1916,7 @@
   <Game>
     <name>ESPN Baseball Tonight</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>8606d69b</crc>
     <date>1994-05-01</date>
     <publisher>Sony</publisher>
@@ -1926,7 +1927,7 @@
   <Game>
     <name>ESPN National Hockey Night</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>75058ede</crc>
     <date>1994-01-01</date>
     <publisher>Sony</publisher>
@@ -1937,7 +1938,7 @@
   <Game>
     <name>ESPN Speedworld</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>c2cff05a</crc>
     <date>1994-01-01</date>
     <publisher>Sony</publisher>
@@ -1948,7 +1949,7 @@
   <Game>
     <name>ESPN Sunday Night NFL</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>26849f90</crc>
     <date>1994-01-01</date>
     <publisher>Sony Imagesoft</publisher>
@@ -1969,7 +1970,7 @@
   </Game>
   <Game>
     <name>Exertainment Mountain Bike Rally</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>e6ede101</crc>
     <date>1994</date>
@@ -1981,7 +1982,7 @@
   <Game>
     <name>Extra Innings</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>440a4250</crc>
     <date>1991-01-01</date>
     <publisher>Sony</publisher>
@@ -2003,7 +2004,7 @@
   <Game>
     <name>F-Zero</name>
     <players>1</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>aa0e31de</crc>
     <date>1991-08-23</date>
     <publisher>Nintendo</publisher>
@@ -2014,7 +2015,7 @@
   <Game>
     <name>F1 Pole Position</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>b3da1b1d</crc>
     <date>1993-01-01</date>
     <publisher>Ubisoft</publisher>
@@ -2069,7 +2070,7 @@
   <Game>
     <name>Faceball 2000</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>8d4df815</crc>
     <date>1992-01-01</date>
     <publisher>Bullet Proof Software</publisher>
@@ -2080,7 +2081,7 @@
   <Game>
     <name>Family Dog</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>1b53c15a</crc>
     <date>1992-01-01</date>
     <publisher>Malibu Games</publisher>
@@ -2091,7 +2092,7 @@
   <Game>
     <name>Family Feud</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>0c664b71</crc>
     <date>1993-01-01</date>
     <publisher>Gametek</publisher>
@@ -2102,7 +2103,7 @@
   <Game>
     <name>Fatal Fury</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>c67257d0</crc>
     <date>1991-12-20</date>
     <publisher>SNk</publisher>
@@ -2113,7 +2114,7 @@
   <Game>
     <name>Fatal Fury 2</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>a26ebfef</crc>
     <date>1993-11-26</date>
     <publisher>Takara</publisher>
@@ -2124,7 +2125,7 @@
   <Game>
     <name>Fatal Fury Special</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>93935bee</crc>
     <date>1994-07-29</date>
     <publisher>Takara</publisher>
@@ -2146,7 +2147,7 @@
   <Game>
     <name>FIFA International Soccer</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>56296426</crc>
     <date>1994-01-01</date>
     <publisher>Laguna</publisher>
@@ -2179,7 +2180,7 @@
   <Game>
     <name>Fighter's History</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>3d17f6ea</crc>
     <date>1994-05-27</date>
     <publisher>Data East</publisher>
@@ -2223,7 +2224,7 @@
   <Game>
     <name>Final Fight</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>4cab21db</crc>
     <date>1991-09-01</date>
     <publisher>Capcom</publisher>
@@ -2234,7 +2235,7 @@
   <Game>
     <name>Final Fight 2</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>8c37ff55</crc>
     <date>1993-05-22</date>
     <publisher>Capcom</publisher>
@@ -2245,7 +2246,7 @@
   <Game>
     <name>Final Fight 3</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>a916e708</crc>
     <date>1995-12-22</date>
     <publisher>Capcom</publisher>
@@ -2266,7 +2267,7 @@
   </Game>
   <Game>
     <name>Fire Striker</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>e500c7ba</crc>
     <date>1994-10-14</date>
@@ -2300,7 +2301,7 @@
   <Game>
     <name>First Samurai</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>4f0a1e2a</crc>
     <date>1991-10-07</date>
     <publisher>Image Works</publisher>
@@ -2344,7 +2345,7 @@
   <Game>
     <name>Football Fury</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>729a5524</crc>
     <date>1993-01-01</date>
     <publisher>American Sammy</publisher>
@@ -2377,7 +2378,7 @@
   <Game>
     <name>Frantic Flea</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>ffa8d1ff</crc>
     <date>1996-04-01</date>
     <publisher>GameTek</publisher>
@@ -2443,7 +2444,7 @@
   <Game>
     <name>George Foreman's KO Boxing</name>
     <players>2</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>15194fc9</crc>
     <date>1992-01-01</date>
     <publisher>Acclaim</publisher>
@@ -2454,7 +2455,7 @@
   <Game>
     <name>Ghoul Patrol</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>ea16b5a2</crc>
     <date>1994-11-01</date>
     <publisher>LucasArts</publisher>
@@ -2464,7 +2465,7 @@
   </Game>
   <Game>
     <name>Goal!</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>935ea22c</crc>
     <date>1992-12-01</date>
@@ -2476,7 +2477,7 @@
   <Game>
     <name>Gods</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>6779970f</crc>
     <date>1992-01-01</date>
     <publisher>Mindscape Inc.</publisher>
@@ -2487,7 +2488,7 @@
   <Game>
     <name>Goof Troop</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>4aafa462</crc>
     <date>1993-07-01</date>
     <publisher>Capcom</publisher>
@@ -2541,7 +2542,7 @@
   </Game>
   <Game>
     <name>Great Waldo Search, The</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>eb49f246</crc>
     <date>1993-06-01</date>
@@ -2585,7 +2586,7 @@
   </Game>
   <Game>
     <name>Hammerlock Wrestling</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>3d2352ea</crc>
     <date>1994-10-01</date>
@@ -2629,7 +2630,7 @@
   </Game>
   <Game>
     <name>Head-On Soccer</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>60dc3634</crc>
     <date>1995-09-01</date>
@@ -2727,7 +2728,7 @@
   </Game>
   <Game>
     <name>Hungry Dinosaurs</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>5c4b2544</crc>
     <date>1994-10-19</date>
@@ -2738,7 +2739,7 @@
   </Game>
   <Game>
     <name>Hunt for Red October, The</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>c796e830</crc>
     <date>1990-10-07</date>
@@ -2783,7 +2784,7 @@
   <Game>
     <name>Ignition Factor, The</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>ee441564</crc>
     <date>1994-11-11</date>
     <publisher>Jaleco</publisher>
@@ -2925,7 +2926,7 @@
   </Game>
   <Game>
     <name>Irem Skins Game, The</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>b95ddc44</crc>
     <date>1992-10-01</date>
@@ -2947,7 +2948,7 @@
   </Game>
   <Game>
     <name>Izzy's Quest for the Olympic Rings</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>e9bb68c7</crc>
     <date>1995-11-01</date>
@@ -2958,7 +2959,7 @@
   </Game>
   <Game>
     <name>J.R.R. Tolkien's The Lord of the Rings - Volume 1</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>1</simultaneous>
     <crc>cd2150c8</crc>
     <date>1994-10-01</date>
@@ -2969,7 +2970,7 @@
   </Game>
   <Game>
     <name>Jack Nicklaus Golf</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>9abc58e2</crc>
     <date>1992-01-01</date>
@@ -2980,7 +2981,7 @@
   </Game>
   <Game>
     <name>James Bond Jr</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>69c2f850</crc>
     <date>1992-10-01</date>
@@ -3002,7 +3003,7 @@
   </Game>
   <Game>
     <name>Jelly Boy</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>f8c72a24</crc>
     <date>1995-03-01</date>
@@ -3079,7 +3080,7 @@
   </Game>
   <Game>
     <name>Jimmy Connors Pro Tennis Tour</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>913f1555</crc>
     <date>1993-10-29</date>
@@ -3123,7 +3124,7 @@
   </Game>
   <Game>
     <name>John Madden Football '93</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>dc5a250b</crc>
     <date>1992-11-01</date>
@@ -3167,7 +3168,7 @@
   </Game>
   <Game>
     <name>Jungle Strike</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>335487e5</crc>
     <date>1995-06-01</date>
@@ -3189,13 +3190,14 @@
   </Game>
   <Game>
     <name>Jurassic Park II - The Chaos Continues</name>
-    <players/>
-    <simultaneous/>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
     <crc>836ee990</crc>
-    <date>1994</date>
-    <publisher>Ocean</publisher>
+    <date>1994-11-01</date>
+    <publisher>Ocean Software</publisher>
     <region>USA</region>
-    <cover/>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1997-1.jpg</cover>
+    <api_id>1997</api_id>
   </Game>
   <Game>
     <name>Justice League Task Force</name>
@@ -3221,7 +3223,7 @@
   </Game>
   <Game>
     <name>Kawasaki Caribbean Challenge</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>37d8ac57</crc>
     <date>1993-06-01</date>
@@ -3243,7 +3245,7 @@
   </Game>
   <Game>
     <name>Ken Griffey Jr. Presents Major League Baseball</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>8bf2b589</crc>
     <date>1994-03-01</date>
@@ -3254,7 +3256,7 @@
   </Game>
   <Game>
     <name>Ken Griffey Jr.'s Winning Run</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>e9b4bd73</crc>
     <date>1995-06-01</date>
@@ -3287,7 +3289,7 @@
   </Game>
   <Game>
     <name>Kick Off</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>a1306f3b</crc>
     <date>1993-07-22</date>
@@ -3298,7 +3300,7 @@
   </Game>
   <Game>
     <name>Kick Off 3 - European Challenge</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>1ac7f523</crc>
     <date>1994-01-01</date>
@@ -3321,7 +3323,7 @@
   <Game>
     <name>Killer Instinct</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>09e9a04e</crc>
     <date>1995-08-01</date>
     <publisher>Nintendo</publisher>
@@ -3354,7 +3356,7 @@
   <Game>
     <name>King of Dragons, The</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>dd505df7</crc>
     <date>1994-01-01</date>
     <publisher>Capcom</publisher>
@@ -3365,7 +3367,7 @@
   <Game>
     <name>King of the Monsters</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>c285c7ff</crc>
     <date>1992-01-01</date>
     <publisher>Takara</publisher>
@@ -3387,7 +3389,7 @@
   <Game>
     <name>Kirby Super Star</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>89d0f7dc</crc>
     <date>1996-09-20</date>
     <publisher>Nintendo</publisher>
@@ -3398,7 +3400,7 @@
   <Game>
     <name>Kirby's Avalanche</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>21e658b8</crc>
     <date>1995-02-01</date>
     <publisher>Nintendo</publisher>
@@ -3420,7 +3422,7 @@
   <Game>
     <name>Kirby's Dream Land 3</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>ec8a48f6</crc>
     <date>1997-11-01</date>
     <publisher>Nintendo</publisher>
@@ -3430,8 +3432,8 @@
   </Game>
   <Game>
     <name>Knights of the Round</name>
-    <players>3</players>
-    <simultaneous>0</simultaneous>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
     <crc>aaa82126</crc>
     <date>1991-11-27</date>
     <publisher>Capcom</publisher>
@@ -3485,7 +3487,7 @@
   </Game>
   <Game>
     <name>Last Action Hero</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>88017df9</crc>
     <date>1993-10-01</date>
@@ -3562,7 +3564,7 @@
   </Game>
   <Game>
     <name>Lester the Unlikely</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>1a52fee5</crc>
     <date>1994-01-01</date>
@@ -3573,7 +3575,7 @@
   </Game>
   <Game>
     <name>Lethal Enforcers</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>5aff8cd5</crc>
     <date>1994-01-03</date>
@@ -3584,7 +3586,7 @@
   </Game>
   <Game>
     <name>Lethal Weapon</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>a14c3dbc</crc>
     <date>1992-12-01</date>
@@ -3617,7 +3619,7 @@
   </Game>
   <Game>
     <name>Lock On</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>84f7e078</crc>
     <date>1993-10-01</date>
@@ -3628,7 +3630,7 @@
   </Game>
   <Game>
     <name>Looney Tunes B-Ball</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>6d3bc96f</crc>
     <date>1995-02-01</date>
@@ -3694,7 +3696,7 @@
   </Game>
   <Game>
     <name>Madden NFL '94</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>8bed5914</crc>
     <date>1993-10-01</date>
@@ -3705,7 +3707,7 @@
   </Game>
   <Game>
     <name>Madden NFL 95</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>021a3f69</crc>
     <date>1994-11-01</date>
@@ -3727,7 +3729,7 @@
   </Game>
   <Game>
     <name>Madden NFL 97</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>abcf026e</crc>
     <date>1996-10-01</date>
@@ -3738,7 +3740,7 @@
   </Game>
   <Game>
     <name>Madden NFL 98</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>cf10cc01</crc>
     <date>1997-11-01</date>
@@ -3749,7 +3751,7 @@
   </Game>
   <Game>
     <name>Magic Boy</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>ab57a2f9</crc>
     <date>1996-08-01</date>
@@ -3760,7 +3762,7 @@
   </Game>
   <Game>
     <name>Magic Sword</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>27325e4d</crc>
     <date>1992-05-29</date>
@@ -3782,7 +3784,7 @@
   </Game>
   <Game>
     <name>Manchester United Championship Soccer</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>8d2596a7</crc>
     <date>1995-01-01</date>
@@ -3859,7 +3861,7 @@
   </Game>
   <Game>
     <name>Mark Davis' The Fishing Master</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>22a109b9</crc>
     <date>1996-04-01</date>
@@ -3881,7 +3883,7 @@
   </Game>
   <Game>
     <name>Marvel Super Heroes - War of the Gems</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>00af56e8</crc>
     <date>1996-10-18</date>
@@ -3892,7 +3894,7 @@
   </Game>
   <Game>
     <name>Mary Shelley's Frankenstein</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>91415d1e</crc>
     <date>1994-11-01</date>
@@ -3914,7 +3916,7 @@
   </Game>
   <Game>
     <name>Math Blaster - Episode 1</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>4c4e5f4a</crc>
     <date>1994-10-01</date>
@@ -3936,7 +3938,7 @@
   </Game>
   <Game>
     <name>Mecarobot Golf</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>82ceee3a</crc>
     <date>1993-09-01</date>
@@ -3969,7 +3971,7 @@
   </Game>
   <Game>
     <name>Mega lo Mania</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>e8042edf</crc>
     <date>1994-01-01</date>
@@ -3981,7 +3983,7 @@
   <Game>
     <name>Mega Man 7</name>
     <players>1</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>2d947536</crc>
     <date>1995-03-24</date>
     <publisher>Capcom</publisher>
@@ -3992,7 +3994,7 @@
   <Game>
     <name>Mega Man Soccer</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>fa9ee2ce</crc>
     <date>1994-04-01</date>
     <publisher>Capcom</publisher>
@@ -4035,7 +4037,7 @@
   </Game>
   <Game>
     <name>Metal Combat - Falcon's Revenge</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>c3131b49</crc>
     <date>1993-09-17</date>
@@ -4046,7 +4048,7 @@
   </Game>
   <Game>
     <name>Metal Marines</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>66787df6</crc>
     <date>1993-12-01</date>
@@ -4057,7 +4059,7 @@
   </Game>
   <Game>
     <name>Metal Morph</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>0adaa9da</crc>
     <date>1994-12-01</date>
@@ -4069,7 +4071,7 @@
   <Game>
     <name>Metal Warriors</name>
     <players>1</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>f2ab92d4</crc>
     <date>1995-04-01</date>
     <publisher>Konami</publisher>
@@ -4079,7 +4081,7 @@
   </Game>
   <Game>
     <name>Michael Andretti's IndyCar Challenge</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>0fdb210e</crc>
     <date>1994-09-01</date>
@@ -4134,7 +4136,7 @@
   </Game>
   <Game>
     <name>Micro Machines</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>364e68bb</crc>
     <date>1994-12-01</date>
@@ -4145,7 +4147,7 @@
   </Game>
   <Game>
     <name>Micro Machines 2 - Turbo Tournament</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>1619b619</crc>
     <date>1996-02-22</date>
@@ -4178,7 +4180,7 @@
   </Game>
   <Game>
     <name>Mighty Max</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>6fc3c105</crc>
     <date>1995-02-01</date>
@@ -4190,7 +4192,7 @@
   <Game>
     <name>Mighty Morphin Power Rangers</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>a56eb77a</crc>
     <date>1994-09-01</date>
     <publisher>Bandai</publisher>
@@ -4222,7 +4224,7 @@
   </Game>
   <Game>
     <name>MLBPA Baseball</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>62a92e57</crc>
     <date>1994-03-01</date>
@@ -4244,7 +4246,7 @@
   </Game>
   <Game>
     <name>Monopoly</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>88d54085</crc>
     <date>1992-01-01</date>
@@ -4256,7 +4258,7 @@
   <Game>
     <name>Mortal Kombat</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>def42945</crc>
     <date>1993-09-13</date>
     <publisher>Acclaim</publisher>
@@ -4267,7 +4269,7 @@
   <Game>
     <name>Mortal Kombat 3</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>4e6af725</crc>
     <date>1995-10-01</date>
     <publisher>Williams</publisher>
@@ -4278,7 +4280,7 @@
   <Game>
     <name>Mortal Kombat II</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>70bb5513</crc>
     <date>1994-09-01</date>
     <publisher>Acclaim</publisher>
@@ -4354,7 +4356,7 @@
   </Game>
   <Game>
     <name>NBA Give 'n Go</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>68c8b643</crc>
     <date>1995-11-01</date>
@@ -4388,7 +4390,7 @@
   <Game>
     <name>NBA Jam - Tournament Edition</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>1fbc1ddb</crc>
     <date>1995-02-23</date>
     <publisher>Acclaim</publisher>
@@ -4398,7 +4400,7 @@
   </Game>
   <Game>
     <name>NBA Live 95</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>1cd2393d</crc>
     <date>1994-12-03</date>
@@ -4409,7 +4411,7 @@
   </Game>
   <Game>
     <name>NBA Live 96</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>042a6495</crc>
     <date>1995-01-01</date>
@@ -4420,7 +4422,7 @@
   </Game>
   <Game>
     <name>NBA Live 97</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>5115b8e5</crc>
     <date>1996-01-01</date>
@@ -4431,7 +4433,7 @@
   </Game>
   <Game>
     <name>NBA Live 98</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>514bfcb5</crc>
     <date>1997-01-01</date>
@@ -4530,7 +4532,7 @@
   </Game>
   <Game>
     <name>NFL Quarterback Club 96</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>e557689f</crc>
     <date>1995-11-01</date>
@@ -4541,8 +4543,8 @@
   </Game>
   <Game>
     <name>NHL '94</name>
-    <players/>
-    <simultaneous>0</simultaneous>
+    <players>1</players>
+    <simultaneous>1</simultaneous>
     <crc>42212a77</crc>
     <date>1993-10-01</date>
     <publisher>Electronic Arts</publisher>
@@ -4585,7 +4587,7 @@
   </Game>
   <Game>
     <name>NHL '98</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>03cad2d2</crc>
     <date>1997-01-01</date>
@@ -4596,7 +4598,7 @@
   </Game>
   <Game>
     <name>NHL Stanley Cup</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>584ce502</crc>
     <date>1993-11-02</date>
@@ -4673,7 +4675,7 @@
   </Game>
   <Game>
     <name>Nobunaga's Ambition</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>49da3583</crc>
     <date>1993-01-01</date>
@@ -4684,7 +4686,7 @@
   </Game>
   <Game>
     <name>Nobunaga's Ambition - Lord of Darkness</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>4d7b39cd</crc>
     <date>1994-10-01</date>
@@ -4816,7 +4818,7 @@
   </Game>
   <Game>
     <name>Out of This World</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>5f40a869</crc>
     <date>1992-11-01</date>
@@ -4849,7 +4851,7 @@
   </Game>
   <Game>
     <name>P.T.O. - Pacific Theater of Operations</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>e51bbac8</crc>
     <date>1993-09-01</date>
@@ -4893,7 +4895,7 @@
   </Game>
   <Game>
     <name>Pac-Man 2 - The New Adventures</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>9fc62bcc</crc>
     <date>1994-09-01</date>
@@ -4948,17 +4950,18 @@
   </Game>
   <Game>
     <name>Parodius</name>
-    <players/>
-    <simultaneous/>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
     <crc>6ffa308c</crc>
-    <date>1992</date>
+    <date>1992-01-01</date>
     <publisher>Konami</publisher>
     <region>Europe</region>
-    <cover/>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2200-2.jpg</cover>
+    <api_id>2200</api_id>
   </Game>
   <Game>
     <name>Peace Keepers, The</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>8071e5db</crc>
     <date>1994-01-01</date>
@@ -4969,7 +4972,7 @@
   </Game>
   <Game>
     <name>PGA European Tour</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>914f2ea3</crc>
     <date>1996-01-01</date>
@@ -4980,7 +4983,7 @@
   </Game>
   <Game>
     <name>PGA Tour 96</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>bc5df071</crc>
     <date>1995-01-01</date>
@@ -4991,7 +4994,7 @@
   </Game>
   <Game>
     <name>PGA Tour Golf</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>b6566944</crc>
     <date>1991-01-01</date>
@@ -5024,7 +5027,7 @@
   </Game>
   <Game>
     <name>Pieces</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>bb6c3c54</crc>
     <date>1994-12-01</date>
@@ -5046,7 +5049,7 @@
   </Game>
   <Game>
     <name>Pinball Dreams</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>81107ce2</crc>
     <date>1994-04-01</date>
@@ -5057,7 +5060,7 @@
   </Game>
   <Game>
     <name>Pinball Fantasies</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>822ad378</crc>
     <date>1995-02-01</date>
@@ -5091,7 +5094,7 @@
   <Game>
     <name>Pirates of Dark Water, The</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>7ca0ca4d</crc>
     <date>1994-01-01</date>
     <publisher>Mitsui</publisher>
@@ -5135,7 +5138,7 @@
   <Game>
     <name>Pocky &amp; Rocky</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>2b0e7ea3</crc>
     <date>1993-06-01</date>
     <publisher>Natsume</publisher>
@@ -5156,8 +5159,8 @@
   </Game>
   <Game>
     <name>Pop'n TwinBee</name>
-    <players/>
-    <simultaneous>0</simultaneous>
+    <players>1</players>
+    <simultaneous>1</simultaneous>
     <crc>588a9707</crc>
     <date>1993-01-01</date>
     <publisher>Konami</publisher>
@@ -5211,7 +5214,7 @@
   </Game>
   <Game>
     <name>Power Drive</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>0bfdca70</crc>
     <date>1994-01-01</date>
@@ -5223,7 +5226,7 @@
   <Game>
     <name>Power Instinct</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>cb8a4f8e</crc>
     <date>1994-01-01</date>
     <publisher>Atlus</publisher>
@@ -5289,7 +5292,7 @@
   <Game>
     <name>Primal Rage</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>3753e4b6</crc>
     <date>1995-08-01</date>
     <publisher>Time Warner Interactive</publisher>
@@ -5354,7 +5357,7 @@
   </Game>
   <Game>
     <name>Putty Squad</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>c061f0a8</crc>
     <date>1994-01-01</date>
@@ -5420,7 +5423,7 @@
   </Game>
   <Game>
     <name>Raiden Trad</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>02ce6c96</crc>
     <date>1992-04-01</date>
@@ -5432,7 +5435,7 @@
   <Game>
     <name>Rampart</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>aed8892a</crc>
     <date>1991-01-01</date>
     <publisher>Electronic Arts</publisher>
@@ -5541,7 +5544,7 @@
   </Game>
   <Game>
     <name>Revolution X</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>0dc5e7ba</crc>
     <date>1995-12-01</date>
@@ -5585,8 +5588,8 @@
   </Game>
   <Game>
     <name>Rise of the Robots</name>
-    <players/>
-    <simultaneous>0</simultaneous>
+    <players>1</players>
+    <simultaneous>1</simultaneous>
     <crc>83ba0ac0</crc>
     <date>1994-12-01</date>
     <publisher>Acclaim</publisher>
@@ -5597,7 +5600,7 @@
   <Game>
     <name>Rival Turf!</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>ca988f59</crc>
     <date>1992-03-06</date>
     <publisher>Jaleco USA</publisher>
@@ -5618,7 +5621,7 @@
   </Game>
   <Game>
     <name>Road Runner's Death Valley Rally</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>5980d75d</crc>
     <date>1992-11-01</date>
@@ -5629,7 +5632,7 @@
   </Game>
   <Game>
     <name>RoboCop 3</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>3502f9b3</crc>
     <date>1992-09-01</date>
@@ -5640,7 +5643,7 @@
   </Game>
   <Game>
     <name>RoboCop versus The Terminator</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>f5ab5d91</crc>
     <date>1993-10-07</date>
@@ -5684,7 +5687,7 @@
   </Game>
   <Game>
     <name>Rocko's Modern Life - Spunky's Dangerous Day</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>197b4cba</crc>
     <date>1994-04-01</date>
@@ -5695,7 +5698,7 @@
   </Game>
   <Game>
     <name>Rocky Rodent</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>c81a7b07</crc>
     <date>1993-09-01</date>
@@ -5717,7 +5720,7 @@
   </Game>
   <Game>
     <name>Romance of the Three Kingdoms II</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>8033574a</crc>
     <date>1992-01-01</date>
@@ -5728,7 +5731,7 @@
   </Game>
   <Game>
     <name>Romance of the Three Kingdoms III - Dragon of Destiny</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>523b0d02</crc>
     <date>1993-01-01</date>
@@ -5739,7 +5742,7 @@
   </Game>
   <Game>
     <name>Romance of the Three Kingdoms IV - Wall of Fire</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>82af5b69</crc>
     <date>1995-07-01</date>
@@ -5773,7 +5776,7 @@
   <Game>
     <name>Samurai Shodown</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>2e614a53</crc>
     <date>1994-11-01</date>
     <publisher>Takara</publisher>
@@ -5783,8 +5786,8 @@
   </Game>
   <Game>
     <name>Saturday Night Slam Masters</name>
-    <players>4+</players>
-    <simultaneous>0</simultaneous>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
     <crc>54161830</crc>
     <date>1994-01-01</date>
     <publisher>Avalon</publisher>
@@ -5827,7 +5830,7 @@
   </Game>
   <Game>
     <name>Secret of Mana</name>
-    <players>3</players>
+    <players>2</players>
     <simultaneous>1</simultaneous>
     <crc>d0176b24</crc>
     <date>1993-08-06</date>
@@ -5872,7 +5875,7 @@
   <Game>
     <name>Shaq Fu</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>52916c9d</crc>
     <date>1994-10-01</date>
     <publisher>Electronic Arts</publisher>
@@ -5970,7 +5973,7 @@
   </Game>
   <Game>
     <name>Skuljagger - Revolt of the Westicans</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>e58a6d01</crc>
     <date>1992-10-01</date>
@@ -6003,7 +6006,7 @@
   </Game>
   <Game>
     <name>Smash Tennis</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>6f7d1745</crc>
     <date>1994-01-01</date>
@@ -6179,7 +6182,7 @@
   </Game>
   <Game>
     <name>Spectre</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>ade6e0d8</crc>
     <date>1994-05-01</date>
@@ -6267,13 +6270,14 @@
   </Game>
   <Game>
     <name>Sporting News Power Baseball, The</name>
-    <players/>
-    <simultaneous/>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
     <crc>315af696</crc>
-    <date>1995</date>
-    <publisher>Hudson</publisher>
+    <date>1995-01-01</date>
+    <publisher>Hudson Soft</publisher>
     <region>USA</region>
-    <cover/>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6291-1.jpg</cover>
+    <api_id>6291</api_id>
   </Game>
   <Game>
     <name>Sports Illustrated Championship Football &amp; Baseball</name>
@@ -6321,7 +6325,7 @@
   </Game>
   <Game>
     <name>Star Trek - Starfleet Academy - Starship Bridge Simulator</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>2db38d24</crc>
     <date>1994-12-01</date>
@@ -6332,7 +6336,7 @@
   </Game>
   <Game>
     <name>Star Trek - The Next Generation - Future's Past</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>8de80428</crc>
     <date>1994-03-01</date>
@@ -6399,7 +6403,7 @@
   <Game>
     <name>Street Fighter Alpha 2</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>9c59ddff</crc>
     <date>1996-12-20</date>
     <publisher>Capcom</publisher>
@@ -6410,7 +6414,7 @@
   <Game>
     <name>Street Fighter II</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>bc3dcd9d</crc>
     <date>1992-06-10</date>
     <publisher>Capcom</publisher>
@@ -6431,7 +6435,7 @@
   </Game>
   <Game>
     <name>Street Hockey '95</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>97357a1b</crc>
     <date>1994-01-01</date>
@@ -6442,8 +6446,8 @@
   </Game>
   <Game>
     <name>Street Racer</name>
-    <players>4+</players>
-    <simultaneous>0</simultaneous>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
     <crc>63e8b7d5</crc>
     <date>1994-12-01</date>
     <publisher>Ubisoft</publisher>
@@ -6453,7 +6457,7 @@
   </Game>
   <Game>
     <name>Strike Gunner S.T.G</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>d054e288</crc>
     <date>1995-01-01</date>
@@ -6465,7 +6469,7 @@
   <Game>
     <name>Stunt Race FX</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>380c2635</crc>
     <date>1994-07-01</date>
     <publisher>Nintendo</publisher>
@@ -6508,7 +6512,7 @@
   </Game>
   <Game>
     <name>Super Alfred Chicken</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>f21c5a9d</crc>
     <date>1994-02-01</date>
@@ -6530,7 +6534,7 @@
   </Game>
   <Game>
     <name>Super Baseball Simulator 1.000</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>aa760fec</crc>
     <date>1991-12-01</date>
@@ -6629,8 +6633,8 @@
   </Game>
   <Game>
     <name>Super Bomberman</name>
-    <players>4+</players>
-    <simultaneous>0</simultaneous>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
     <crc>63a8e2c6</crc>
     <date>1993-09-01</date>
     <publisher>Hudson Soft</publisher>
@@ -6640,8 +6644,8 @@
   </Game>
   <Game>
     <name>Super Bomberman 2</name>
-    <players>4+</players>
-    <simultaneous>0</simultaneous>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
     <crc>9c1f11e4</crc>
     <date>1994-12-12</date>
     <publisher>Hudson Soft</publisher>
@@ -6651,8 +6655,8 @@
   </Game>
   <Game>
     <name>Super Bomberman 3</name>
-    <players>4+</players>
-    <simultaneous>0</simultaneous>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
     <crc>a096a6e5</crc>
     <date>1995-01-01</date>
     <publisher>Hudson Soft</publisher>
@@ -6673,7 +6677,7 @@
   </Game>
   <Game>
     <name>Super Bowling</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>94945b50</crc>
     <date>1992-01-01</date>
@@ -6816,7 +6820,7 @@
   </Game>
   <Game>
     <name>Super Ice Hockey</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>fb1d16c4</crc>
     <date>1994-03-25</date>
@@ -6850,7 +6854,7 @@
   <Game>
     <name>Super Mario All-Stars</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>925637c7</crc>
     <date>1993-08-01</date>
     <publisher>Nintendo</publisher>
@@ -6872,7 +6876,7 @@
   <Game>
     <name>Super Mario Kart</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>cd80db86</crc>
     <date>1992-09-01</date>
     <publisher>Nintendo</publisher>
@@ -6905,7 +6909,7 @@
   <Game>
     <name>Super Mario World 2 - Yoshi's Island</name>
     <players>1</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>cf98ddaa</crc>
     <date>1995-10-04</date>
     <publisher>Nintendo</publisher>
@@ -6970,8 +6974,8 @@
   </Game>
   <Game>
     <name>Super Off Road</name>
-    <players>4+</players>
-    <simultaneous>0</simultaneous>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
     <crc>fe263383</crc>
     <date>1991-12-01</date>
     <publisher>Tradewest</publisher>
@@ -6981,7 +6985,7 @@
   </Game>
   <Game>
     <name>Super Off Road - The Baja</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>cb483ead</crc>
     <date>1993-09-01</date>
@@ -6992,7 +6996,7 @@
   </Game>
   <Game>
     <name>Super Pinball - Behind the Mask</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>008463a0</crc>
     <date>1994-01-01</date>
@@ -7092,7 +7096,7 @@
   <Game>
     <name>Super Smash T.V.</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>2d0b20d0</crc>
     <date>1992-02-01</date>
     <publisher>Acclaim</publisher>
@@ -7169,7 +7173,7 @@
   <Game>
     <name>Super Street Fighter II</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>f16d5ce9</crc>
     <date>1994-06-01</date>
     <publisher>CAPCOM</publisher>
@@ -7257,7 +7261,7 @@
   <Game>
     <name>Suzuka 8 Hours</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>54740b9b</crc>
     <date>1993-01-01</date>
     <publisher>Namco</publisher>
@@ -7389,7 +7393,7 @@
   <Game>
     <name>Teenage Mutant Ninja Turtles - Tournament Fighters</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>e2fe5dbf</crc>
     <date>1993-09-04</date>
     <publisher>Konami</publisher>
@@ -7400,7 +7404,7 @@
   <Game>
     <name>Teenage Mutant Ninja Turtles IV - Turtles in Time</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>5940bd99</crc>
     <date>1992-08-01</date>
     <publisher>Konami</publisher>
@@ -7444,7 +7448,7 @@
   <Game>
     <name>Tetris &amp; Dr. Mario</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>6c852ef3</crc>
     <date>1994-12-01</date>
     <publisher>Nintendo</publisher>
@@ -7455,7 +7459,7 @@
   <Game>
     <name>Tetris 2</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>3bc7054a</crc>
     <date>1994-08-08</date>
     <publisher>Nintendo</publisher>
@@ -7466,7 +7470,7 @@
   <Game>
     <name>Tetris Attack</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>6c128210</crc>
     <date>1996-11-03</date>
     <publisher>Nintendo</publisher>
@@ -7554,7 +7558,7 @@
   <Game>
     <name>Timon &amp; Pumbaa's Jungle Games</name>
     <players>1</players>
-    <simultaneous/>
+    <simultaneous>0</simultaneous>
     <crc>341c6fb0</crc>
     <date>1997-01-01</date>
     <publisher>THQ</publisher>
@@ -7585,7 +7589,7 @@
   </Game>
   <Game>
     <name>Tintin in Tibet</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>f1dce2b7</crc>
     <date>1995-12-15</date>
@@ -7607,7 +7611,7 @@
   </Game>
   <Game>
     <name>Tiny Toon Adventures - Wacky Sports Challenge</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>afe72ff0</crc>
     <date>1994-12-01</date>
@@ -7685,7 +7689,7 @@
   <Game>
     <name>Top Gear 2</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>2b88bee8</crc>
     <date>1993-01-01</date>
     <publisher>Kemco</publisher>
@@ -7695,7 +7699,7 @@
   </Game>
   <Game>
     <name>Top Gear 3000</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>a20be998</crc>
     <date>1994-01-01</date>
@@ -7806,7 +7810,7 @@
   <Game>
     <name>Tuff E Nuff</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>865f37bf</crc>
     <date>1993-03-26</date>
     <publisher>Jaleco Entertainment</publisher>
@@ -7816,8 +7820,8 @@
   </Game>
   <Game>
     <name>Turbo Toons</name>
-    <players>4+</players>
-    <simultaneous/>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
     <crc>26a9c3f4</crc>
     <date>1994-01-01</date>
     <publisher>Allan</publisher>
@@ -7905,7 +7909,7 @@
   <Game>
     <name>Ultimate Mortal Kombat 3</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>f5bfe41e</crc>
     <date>1996-10-01</date>
     <publisher>Williams</publisher>
@@ -7992,7 +7996,7 @@
   </Game>
   <Game>
     <name>Vegas Stakes</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>03a0e935</crc>
     <date>1993-01-01</date>
@@ -8168,7 +8172,7 @@
   </Game>
   <Game>
     <name>Wheel of Fortune</name>
-    <players>3</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>1c384b11</crc>
     <date>1992-01-01</date>
@@ -8179,7 +8183,7 @@
   </Game>
   <Game>
     <name>Wheel of Fortune - Deluxe Edition</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>d6a5984c</crc>
     <date>1994-04-01</date>
@@ -8235,7 +8239,7 @@
   <Game>
     <name>Wild Guns</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>085d8d14</crc>
     <date>1995-07-01</date>
     <publisher>Natsume</publisher>
@@ -8278,7 +8282,7 @@
   </Game>
   <Game>
     <name>Wings 2 - Aces High</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>1637d1a5</crc>
     <date>1992-10-01</date>
@@ -8300,7 +8304,7 @@
   </Game>
   <Game>
     <name>Winter Olympic Games - Lillehammer '94</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>0704abe4</crc>
     <date>1993-01-01</date>
@@ -8410,7 +8414,7 @@
   <Game>
     <name>World Heroes</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>1228ad30</crc>
     <date>1993-01-01</date>
     <publisher>ADK</publisher>
@@ -8421,7 +8425,7 @@
   <Game>
     <name>World Heroes 2</name>
     <players>2</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>098d7eaa</crc>
     <date>1994-01-01</date>
     <publisher>Takara</publisher>
@@ -8442,7 +8446,7 @@
   </Game>
   <Game>
     <name>World Masters Golf</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>e0ee681f</crc>
     <date>1995-01-01</date>
@@ -8464,7 +8468,7 @@
   </Game>
   <Game>
     <name>Worms</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>90d0fac0</crc>
     <date>1995-01-01</date>
@@ -8475,7 +8479,7 @@
   </Game>
   <Game>
     <name>WWF Raw</name>
-    <players>4+</players>
+    <players>2</players>
     <simultaneous>0</simultaneous>
     <crc>3e0038bf</crc>
     <date>1994-11-25</date>
@@ -8509,7 +8513,7 @@
   <Game>
     <name>WWF WrestleMania - The Arcade Game</name>
     <players>1</players>
-    <simultaneous>0</simultaneous>
+    <simultaneous>1</simultaneous>
     <crc>1ba08495</crc>
     <date>1995-01-01</date>
     <publisher>Cosmo</publisher>
@@ -8519,7 +8523,7 @@
   </Game>
   <Game>
     <name>X Zone</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>99627bb0</crc>
     <date>1992-11-01</date>
@@ -8596,7 +8600,7 @@
   </Game>
   <Game>
     <name>Ys III - Wanderers from Ys</name>
-    <players/>
+    <players>1</players>
     <simultaneous>0</simultaneous>
     <crc>64a91e64</crc>
     <date>1991-09-27</date>
@@ -8626,6 +8630,17 @@
     <region>USA</region>
     <cover>http://thegamesdb.net/banners/boxart/original/front/1361-1.jpg</cover>
     <api_id>1361</api_id>
+  </Game>
+  <Game>
+    <name>Zool - Ninja of the Nth Dimension</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3c10daf1</crc>
+    <date>1994-01-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6373-1.jpg</cover>
+    <api_id>6373</api_id>
   </Game>
   <Game>
     <name>Zool - Ninja of the Nth Dimension</name>

--- a/data/snes.xml
+++ b/data/snes.xml
@@ -1,0 +1,8641 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Data>
+  <Game>
+    <name>2020 Super Baseball</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>0d77933e</crc>
+    <date>1993-03-12</date>
+    <publisher>SNK</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/304-1.jpg</cover>
+    <api_id>304</api_id>
+  </Game>
+  <Game>
+    <name>3 Ninjas Kick Back</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>f2ee11f9</crc>
+    <date>1994-06-19</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/281-1.jpg</cover>
+    <api_id>281</api_id>
+  </Game>
+  <Game>
+    <name>7th Saga, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>b3abdde6</crc>
+    <date>1993-08-03</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/282-2.jpg</cover>
+    <api_id>282</api_id>
+  </Game>
+  <Game>
+    <name>90 Minutes - European Prime Goal</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>1ad61bd0</crc>
+    <date>1995-08-04</date>
+    <publisher>Namco</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/303-2.jpg</cover>
+    <api_id>303</api_id>
+  </Game>
+  <Game>
+    <name>A.S.P. - Air Strike Patrol</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>05c0da54</crc>
+    <date>1995-01-01</date>
+    <publisher>SETA</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/305-1.jpg</cover>
+    <api_id>305</api_id>
+  </Game>
+  <Game>
+    <name>Aaahh!!! Real Monsters</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>27ff5ba1</crc>
+    <date>1995-08-15</date>
+    <publisher>Viacom New Media</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/306-1.jpg</cover>
+    <api_id>306</api_id>
+  </Game>
+  <Game>
+    <name>ABC Monday Night Football</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e0dc8ad7</crc>
+    <date>1993-12-07</date>
+    <publisher>Data East</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1332-1.jpg</cover>
+    <api_id>1332</api_id>
+  </Game>
+  <Game>
+    <name>ACME Animation Factory</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0944a5c3</crc>
+    <date>1994-11-01</date>
+    <publisher>Sunsoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1528-1.jpg</cover>
+    <api_id>1528</api_id>
+  </Game>
+  <Game>
+    <name>ActRaiser</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>eac3358d</crc>
+    <date>1991-11-01</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1046-1.jpg</cover>
+    <api_id>1046</api_id>
+  </Game>
+  <Game>
+    <name>ActRaiser 2</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>4901f718</crc>
+    <date>1993-10-29</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/43500-1.jpg</cover>
+    <api_id>43500</api_id>
+  </Game>
+  <Game>
+    <name>Addams Family Values</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>98b07db8</crc>
+    <date>1995-10-07</date>
+    <publisher>Ocean Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1531-1.jpg</cover>
+    <api_id>1531</api_id>
+  </Game>
+  <Game>
+    <name>Addams Family, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2e8034ab</crc>
+    <date>1992-03-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3668-1.png</cover>
+    <api_id>3668</api_id>
+  </Game>
+  <Game>
+    <name>Addams Family, The - Pugsley's Scavenger Hunt</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>153a00a7</crc>
+    <date>1993-02-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3669-1.png</cover>
+    <api_id>3669</api_id>
+  </Game>
+  <Game>
+    <name>Adventures of Batman &amp; Robin, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>b3ef81f5</crc>
+    <date>1994-12-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1049-1.jpg</cover>
+    <api_id>1049</api_id>
+  </Game>
+  <Game>
+    <name>Adventures of Dr. Franken, The</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>cfab3bba</crc>
+    <date>1993-12-01</date>
+    <publisher>Kemco, DTMC</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1050-1.jpg</cover>
+    <api_id>1050</api_id>
+  </Game>
+  <Game>
+    <name>Adventures of Kid Kleets, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1664ae48</crc>
+    <date>1994-04-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3308-1.jpg</cover>
+    <api_id>3308</api_id>
+  </Game>
+  <Game>
+    <name>Adventures of Rocky and Bullwinkle and Friends, The</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>dc8f5734</crc>
+    <date>1993-06-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3671-1.jpg</cover>
+    <api_id>3671</api_id>
+  </Game>
+  <Game>
+    <name>Adventures of Yogi Bear</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7448d45c</crc>
+    <date>1994-10-01</date>
+    <publisher>Cybersoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3158-1.png</cover>
+    <api_id>3158</api_id>
+  </Game>
+  <Game>
+    <name>Aero Fighters</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>f194d00a</crc>
+    <date>1994-01-01</date>
+    <publisher>Tecmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/203-1.jpg</cover>
+    <api_id>203</api_id>
+  </Game>
+  <Game>
+    <name>Aero the Acro-Bat</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>919f23cb</crc>
+    <date>1993-10-01</date>
+    <publisher>Sunsoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1527-1.jpg</cover>
+    <api_id>1527</api_id>
+  </Game>
+  <Game>
+    <name>Aero the Acro-Bat 2</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8c05ed51</crc>
+    <date>1994-04-01</date>
+    <publisher>Sunsoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1530-2.png</cover>
+    <api_id>1530</api_id>
+  </Game>
+  <Game>
+    <name>Aerobiz</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>54302a46</crc>
+    <date>1993-02-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1534-1.jpg</cover>
+    <api_id>1534</api_id>
+  </Game>
+  <Game>
+    <name>Aerobiz Supersonic</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>efafab12</crc>
+    <date>1994-08-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3159-1.jpg</cover>
+    <api_id>3159</api_id>
+  </Game>
+  <Game>
+    <name>Air Cavalry</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6b452801</crc>
+    <date>1995-06-20</date>
+    <publisher>Cybersoft, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/273-1.jpg</cover>
+    <api_id>273</api_id>
+  </Game>
+  <Game>
+    <name>Al Unser Jr.'s Road to the Top</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>d0550624</crc>
+    <date>1994-11-01</date>
+    <publisher>Software Toolworks</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1605-1.jpg</cover>
+    <api_id>1605</api_id>
+  </Game>
+  <Game>
+    <name>Aladdin</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>124d8e4d</crc>
+    <date>1993-01-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2868-1.jpg</cover>
+    <api_id>2868</api_id>
+  </Game>
+  <Game>
+    <name>Alien 3</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>98e2ac15</crc>
+    <date>1993-01-01</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2970-1.jpg</cover>
+    <api_id>2970</api_id>
+  </Game>
+  <Game>
+    <name>Alien vs. Predator</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1803cf20</crc>
+    <date>1993-01-08</date>
+    <publisher>Activision</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3310-1.jpg</cover>
+    <api_id>3310</api_id>
+  </Game>
+  <Game>
+    <name>American Gladiators</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>76b151fd</crc>
+    <date>1993-04-13</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2761-1.jpg</cover>
+    <api_id>2761</api_id>
+  </Game>
+  <Game>
+    <name>American Tail, An - Fievel Goes West</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>eea38aed</crc>
+    <date>1994-08-30</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1704-1.jpg</cover>
+    <api_id>1704</api_id>
+  </Game>
+  <Game>
+    <name>Andre Agassi Tennis</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>d1ae87be</crc>
+    <date>1994-05-31</date>
+    <publisher>Lance Investments</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3161-1.jpg</cover>
+    <api_id>3161</api_id>
+  </Game>
+  <Game>
+    <name>Animaniacs</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>cf0f14d2</crc>
+    <date>1994-11-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/274-2.jpg</cover>
+    <api_id>274</api_id>
+  </Game>
+  <Game>
+    <name>Arcade's Greatest Hits</name>
+    <players/>
+    <simultaneous/>
+    <crc>471b12b0</crc>
+    <date>1996</date>
+    <publisher>Midway</publisher>
+    <region>USA</region>
+    <cover/>
+  </Game>
+  <Game>
+    <name>Arcade's Greatest Hits - The Atari Collection 1</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>02394f36</crc>
+    <date>1997-08-30</date>
+    <publisher>Midway</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1568-1.jpg</cover>
+    <api_id>1568</api_id>
+  </Game>
+  <Game>
+    <name>Arcana</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c891b297</crc>
+    <date>1992-03-27</date>
+    <publisher>HAL Laboratory</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1707-1.jpg</cover>
+    <api_id>1707</api_id>
+  </Game>
+  <Game>
+    <name>Archer Maclean's Super Dropzone</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e1ccce49</crc>
+    <date>1995-12-01</date>
+    <publisher>Psygnosis</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1569-1.jpg</cover>
+    <api_id>1569</api_id>
+  </Game>
+  <Game>
+    <name>Ardy Lightfoot</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>51a5f489</crc>
+    <date>1993-11-26</date>
+    <publisher>Titus Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/275-1.jpg</cover>
+    <api_id>275</api_id>
+  </Game>
+  <Game>
+    <name>Arkanoid - Doh It Again</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>b50503a0</crc>
+    <date>1997-01-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1570-1.jpg</cover>
+    <api_id>1570</api_id>
+  </Game>
+  <Game>
+    <name>Art of Fighting</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>9fa74067</crc>
+    <date>1992-09-24</date>
+    <publisher>Takara</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1571-1.jpg</cover>
+    <api_id>1571</api_id>
+  </Game>
+  <Game>
+    <name>Asterix &amp; Obelix</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>83af6152</crc>
+    <date>1995-09-28</date>
+    <publisher>Infogrames</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1572-1.png</cover>
+    <api_id>1572</api_id>
+  </Game>
+  <Game>
+    <name>Asterix</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>5ddedc28</crc>
+    <date>1993-01-01</date>
+    <publisher>Infogrames</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3160-1.png</cover>
+    <api_id>3160</api_id>
+  </Game>
+  <Game>
+    <name>Axelay</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f812b533</crc>
+    <date>1992-09-11</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1573-2.jpg</cover>
+    <api_id>1573</api_id>
+  </Game>
+  <Game>
+    <name>B.O.B.</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>4f593c46</crc>
+    <date>1993-01-01</date>
+    <publisher>Electronic Arts, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2763-1.jpg</cover>
+    <api_id>2763</api_id>
+  </Game>
+  <Game>
+    <name>Ballz 3D - Fighting at Its Ballziest</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>1c058b7d</crc>
+    <date>1994-01-01</date>
+    <publisher>Accolade</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3369-1.jpg</cover>
+    <api_id>3369</api_id>
+  </Game>
+  <Game>
+    <name>Barbie Super Model</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>3b73610e</crc>
+    <date>1993-01-01</date>
+    <publisher>Hi-Tech Expressions, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3370-1.png</cover>
+    <api_id>3370</api_id>
+  </Game>
+  <Game>
+    <name>Barbie Vacation Adventure</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8ce1ba79</crc>
+    <date>1994-01-01</date>
+    <publisher>Hi Tech Expressions</publisher>
+    <region>USA) (Proto</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3476-1.jpg</cover>
+    <api_id>3476</api_id>
+  </Game>
+  <Game>
+    <name>Barkley Shut Up and Jam!</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>726b6c5a</crc>
+    <date>1994-06-01</date>
+    <publisher>Den'Z</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1515-1.png</cover>
+    <api_id>1515</api_id>
+  </Game>
+  <Game>
+    <name>BASS Masters Classic</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>832a27c2</crc>
+    <date>1995-06-01</date>
+    <publisher>Black Pearl</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3477-1.jpg</cover>
+    <api_id>3477</api_id>
+  </Game>
+  <Game>
+    <name>BASS Masters Classic - Pro Edition</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c5058634</crc>
+    <date>1996-07-01</date>
+    <publisher>Black Pearl</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3162-1.jpg</cover>
+    <api_id>3162</api_id>
+  </Game>
+  <Game>
+    <name>Bassin's Black Bass</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7dc5b7b3</crc>
+    <date>1994-01-01</date>
+    <publisher>Hot-B</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3145-1.jpg</cover>
+    <api_id>3145</api_id>
+  </Game>
+  <Game>
+    <name>Batman Forever</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>d9b5e9cf</crc>
+    <date>1995-08-07</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3146-1.jpg</cover>
+    <api_id>3146</api_id>
+  </Game>
+  <Game>
+    <name>Batman Returns</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e87dfdf6</crc>
+    <date>1993-03-31</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1517-1.jpg</cover>
+    <api_id>1517</api_id>
+  </Game>
+  <Game>
+    <name>Battle Blaze</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>d933bd8d</crc>
+    <date>1992-10-07</date>
+    <publisher>Sammy</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1708-1.png</cover>
+    <api_id>1708</api_id>
+  </Game>
+  <Game>
+    <name>Battle Cars</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>46043454</crc>
+    <date>1993-10-07</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1709-1.jpg</cover>
+    <api_id>1709</api_id>
+  </Game>
+  <Game>
+    <name>Battle Clash</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>59c00310</crc>
+    <date>1993-06-21</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/276-2.jpg</cover>
+    <api_id>276</api_id>
+  </Game>
+  <Game>
+    <name>Battle Grand Prix</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>190ff436</crc>
+    <date>1992-03-27</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1710-1.png</cover>
+    <api_id>1710</api_id>
+  </Game>
+  <Game>
+    <name>Battletoads &amp; Double Dragon</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>8b18ac01</crc>
+    <date>1993-10-01</date>
+    <publisher>Tradewest</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2772-1.jpg</cover>
+    <api_id>2772</api_id>
+  </Game>
+  <Game>
+    <name>Battletoads in Battlemaniacs</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>617ac925</crc>
+    <date>1993-06-01</date>
+    <publisher>Tradewest</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1606-1.jpg</cover>
+    <api_id>1606</api_id>
+  </Game>
+  <Game>
+    <name>Bazooka Blitzkrieg</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>49c187f3</crc>
+    <date>1992-12-31</date>
+    <publisher>Bandai</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1711-1.png</cover>
+    <api_id>1711</api_id>
+  </Game>
+  <Game>
+    <name>Beauty and the Beast</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>956e183c</crc>
+    <date>1994-01-01</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3170-1.png</cover>
+    <api_id>3170</api_id>
+  </Game>
+  <Game>
+    <name>Beavis and Butt-Head</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>15cf4bd5</crc>
+    <date>1994-07-01</date>
+    <publisher>Viacom New Media</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3860-2.jpg</cover>
+    <api_id>3860</api_id>
+  </Game>
+  <Game>
+    <name>Bebe's Kids</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>bda2e412</crc>
+    <date>1994-04-01</date>
+    <publisher>Motown Games</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1713-1.jpg</cover>
+    <api_id>1713</api_id>
+  </Game>
+  <Game>
+    <name>Beethoven - The Ultimate Canine Caper!</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>beebafa2</crc>
+    <date>1993-01-01</date>
+    <publisher>Hi-Tech Expressions, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1575-2.png</cover>
+    <api_id>1575</api_id>
+  </Game>
+  <Game>
+    <name>Best of the Best - Championship Karate</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>7f6ed86e</crc>
+    <date>1993-01-01</date>
+    <publisher>Loriciel</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3482-1.png</cover>
+    <api_id>3482</api_id>
+  </Game>
+  <Game>
+    <name>Big Sky Trooper</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>25c69316</crc>
+    <date>1995-10-01</date>
+    <publisher>JVC</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1519-1.jpg</cover>
+    <api_id>1519</api_id>
+  </Game>
+  <Game>
+    <name>Biker Mice from Mars</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>4e8b2ecb</crc>
+    <date>1994-12-02</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1520-1.jpg</cover>
+    <api_id>1520</api_id>
+  </Game>
+  <Game>
+    <name>Bill Laimbeer's Combat Basketball</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>468d8cdd</crc>
+    <date>1991-11-01</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1714-1.jpg</cover>
+    <api_id>1714</api_id>
+  </Game>
+  <Game>
+    <name>Bill Walsh College Football</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>25391c9f</crc>
+    <date>1994-01-01</date>
+    <publisher>Electronic Arts, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3483-1.png</cover>
+    <api_id>3483</api_id>
+  </Game>
+  <Game>
+    <name>BioMetal</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>53d8410e</crc>
+    <date>1993-01-01</date>
+    <publisher>Athena</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1576-1.jpg</cover>
+    <api_id>1576</api_id>
+  </Game>
+  <Game>
+    <name>Blackthorne</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>856beab1</crc>
+    <date>1994-09-16</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1521-1.jpg</cover>
+    <api_id>1521</api_id>
+  </Game>
+  <Game>
+    <name>BlaZeon - The Bio-Cyborg Challenge</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>3b01d0a3</crc>
+    <date>1992-01-01</date>
+    <publisher>Atlus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1716-1.png</cover>
+    <api_id>1716</api_id>
+  </Game>
+  <Game>
+    <name>Blues Brothers, The</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>82b97464</crc>
+    <date>1993-03-26</date>
+    <publisher>Titus Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2788-1.jpg</cover>
+    <api_id>2788</api_id>
+  </Game>
+  <Game>
+    <name>Bobby's World</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>18bbee33</crc>
+    <date>1994</date>
+    <publisher>Hi Tech Entertainment</publisher>
+    <region>USA) (Proto</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3484-1.jpg</cover>
+    <api_id>3484</api_id>
+  </Game>
+  <Game>
+    <name>Bonkers</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>597aa981</crc>
+    <date>1994-12-15</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1796-1.jpg</cover>
+    <api_id>1796</api_id>
+  </Game>
+  <Game>
+    <name>Boogerman - A Pick and Flick Adventure</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1899aaff</crc>
+    <date>1995-12-01</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1717-1.jpg</cover>
+    <api_id>1717</api_id>
+  </Game>
+  <Game>
+    <name>Boxing Legends of the Ring</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>c0b632c0</crc>
+    <date>1994-11-01</date>
+    <publisher>Electro Brain</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/17856-1.jpg</cover>
+    <api_id>17856</api_id>
+  </Game>
+  <Game>
+    <name>Brain Lord</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ac443d87</crc>
+    <date>1994-01-29</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1718-1.png</cover>
+    <api_id>1718</api_id>
+  </Game>
+  <Game>
+    <name>Brainies, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>718cb0df</crc>
+    <date>1996-04-01</date>
+    <publisher>Titus Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1587-1.jpg</cover>
+    <api_id>1587</api_id>
+  </Game>
+  <Game>
+    <name>Bram Stoker's Dracula</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>5cece690</crc>
+    <date>1993-09-01</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3072-1.jpg</cover>
+    <api_id>3072</api_id>
+  </Game>
+  <Game>
+    <name>Brandish</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>74f70a0b</crc>
+    <date>1995-02-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1723-1.jpg</cover>
+    <api_id>1723</api_id>
+  </Game>
+  <Game>
+    <name>Brawl Brothers</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e822065c</crc>
+    <date>1993-04-15</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1523-1.jpg</cover>
+    <api_id>1523</api_id>
+  </Game>
+  <Game>
+    <name>BreakThru!</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e6c0b5da</crc>
+    <date>1994-06-01</date>
+    <publisher>Spectrum Holobyte</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2523-1.jpg</cover>
+    <api_id>2523</api_id>
+  </Game>
+  <Game>
+    <name>Breath of Fire</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c788b696</crc>
+    <date>1994-08-01</date>
+    <publisher>Squaresoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/869-2.jpg</cover>
+    <api_id>869</api_id>
+  </Game>
+  <Game>
+    <name>Breath of Fire II</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>67cdacc5</crc>
+    <date>1995-12-03</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/870-2.jpg</cover>
+    <api_id>870</api_id>
+  </Game>
+  <Game>
+    <name>Brett Hull Hockey '95</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>9ebfe809</crc>
+    <date>1994-01-01</date>
+    <publisher>Accolade</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3163-1.jpg</cover>
+    <api_id>3163</api_id>
+  </Game>
+  <Game>
+    <name>Brett Hull Hockey</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>fbe35998</crc>
+    <date>1994-01-01</date>
+    <publisher>Accolade</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1591-1.jpg</cover>
+    <api_id>1591</api_id>
+  </Game>
+  <Game>
+    <name>Bronkie the Bronchiasaurus</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>1200f3cf</crc>
+    <date>1995-09-01</date>
+    <publisher>Raya Systems</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1719-1.jpg</cover>
+    <api_id>1719</api_id>
+  </Game>
+  <Game>
+    <name>Brunswick World Tournament of Champions</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>52e4dc92</crc>
+    <date>1997-08-01</date>
+    <publisher>Black Pearl</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3164-1.png</cover>
+    <api_id>3164</api_id>
+  </Game>
+  <Game>
+    <name>Brutal - Paws of Fury</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>8fe49f80</crc>
+    <date>1994-12-01</date>
+    <publisher>Kemco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1720-2.jpg</cover>
+    <api_id>1720</api_id>
+  </Game>
+  <Game>
+    <name>Bubsy II</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d0d172fa</crc>
+    <date>1994-04-03</date>
+    <publisher>Accolade</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1722-1.jpg</cover>
+    <api_id>1722</api_id>
+  </Game>
+  <Game>
+    <name>Bubsy in Claws Encounters of the Furred Kind</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>444a52c1</crc>
+    <date>1993-01-01</date>
+    <publisher>Accolade</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2232-1.jpg</cover>
+    <api_id>2232</api_id>
+  </Game>
+  <Game>
+    <name>Bugs Bunny - Rabbit Rampage</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>832c0cb6</crc>
+    <date>1994-02-05</date>
+    <publisher>Sunsoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/278-2.jpg</cover>
+    <api_id>278</api_id>
+  </Game>
+  <Game>
+    <name>Bulls vs Blazers and the NBA Playoffs</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>c2e91694</crc>
+    <date>1992-10-07</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1524-1.jpg</cover>
+    <api_id>1524</api_id>
+  </Game>
+  <Game>
+    <name>Bust-A-Move</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>3266fd23</crc>
+    <date>1995-03-01</date>
+    <publisher>Taito Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2040-2.jpg</cover>
+    <api_id>2040</api_id>
+  </Game>
+  <Game>
+    <name>Cacoma Knight in Bizyland</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>ba921443</crc>
+    <date>1993-10-07</date>
+    <publisher>SETA Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/279-1.jpg</cover>
+    <api_id>279</api_id>
+  </Game>
+  <Game>
+    <name>Cal Ripken Jr. Baseball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>ce2eaa41</crc>
+    <date>1992-12-01</date>
+    <publisher>Mindscape Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1593-1.jpg</cover>
+    <api_id>1593</api_id>
+  </Game>
+  <Game>
+    <name>California Games II</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>21392b00</crc>
+    <date>1993-01-01</date>
+    <publisher>DTMC</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2041-1.jpg</cover>
+    <api_id>2041</api_id>
+  </Game>
+  <Game>
+    <name>Cannon Fodder</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f3b5cbb1</crc>
+    <date>1994-01-01</date>
+    <publisher>Virgin Interactive</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1594-2.jpg</cover>
+    <api_id>1594</api_id>
+  </Game>
+  <Game>
+    <name>Cannondale Cup</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>b95fe0a0</crc>
+    <date>1994-01-01</date>
+    <publisher>American Softworks Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3195-1.jpg</cover>
+    <api_id>3195</api_id>
+  </Game>
+  <Game>
+    <name>Capcom's MVP Football</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>bd0a0c0e</crc>
+    <date>1992-01-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3165-1.jpg</cover>
+    <api_id>3165</api_id>
+  </Game>
+  <Game>
+    <name>Capcom's Soccer Shootout</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>ee314ae5</crc>
+    <date>1994-05-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3166-1.jpg</cover>
+    <api_id>3166</api_id>
+  </Game>
+  <Game>
+    <name>Captain America and the Avengers</name>
+    <players>4+</players>
+    <simultaneous>1</simultaneous>
+    <crc>456ab5c8</crc>
+    <date>1993-09-07</date>
+    <publisher>Data East</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1551-1.jpg</cover>
+    <api_id>1551</api_id>
+  </Game>
+  <Game>
+    <name>Captain Commando</name>
+    <players>4+</players>
+    <simultaneous>1</simultaneous>
+    <crc>81db73c7</crc>
+    <date>1991-11-24</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1735-1.jpg</cover>
+    <api_id>1735</api_id>
+  </Game>
+  <Game>
+    <name>Captain Novolin</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>9fd460a4</crc>
+    <date>1992-11-02</date>
+    <publisher>Raya Systems</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1552-1.jpg</cover>
+    <api_id>1552</api_id>
+  </Game>
+  <Game>
+    <name>Carrier Aces</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>8bc5b8de</crc>
+    <date>1995-06-28</date>
+    <publisher>Synergistic Software, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1596-1.jpg</cover>
+    <api_id>1596</api_id>
+  </Game>
+  <Game>
+    <name>Casper</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>a3b745bc</crc>
+    <date>1996-01-01</date>
+    <publisher>Natsume, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2834-1.jpg</cover>
+    <api_id>2834</api_id>
+  </Game>
+  <Game>
+    <name>Castlevania - Dracula X</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7c4887e1</crc>
+    <date>1995-09-05</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1553-1.jpg</cover>
+    <api_id>1553</api_id>
+  </Game>
+  <Game>
+    <name>Champions - World Class Soccer</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>bcd59d08</crc>
+    <date>1994-01-01</date>
+    <publisher>Acclaim Entertainment, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1736-1.jpg</cover>
+    <api_id>1736</api_id>
+  </Game>
+  <Game>
+    <name>Championship Pool</name>
+    <players>4+</players>
+    <simultaneous/>
+    <crc>98ef8414</crc>
+    <date>1993-01-01</date>
+    <publisher>Mindscape, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3485-1.jpg</cover>
+    <api_id>3485</api_id>
+  </Game>
+  <Game>
+    <name>Championship Soccer '94</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>6b953095</crc>
+    <date>1994-06-01</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3755-1.jpg</cover>
+    <api_id>3755</api_id>
+  </Game>
+  <Game>
+    <name>Chavez</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a9d604ea</crc>
+    <date>1994-10-07</date>
+    <publisher>Malibu Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1554-1.jpg</cover>
+    <api_id>1554</api_id>
+  </Game>
+  <Game>
+    <name>Chavez II</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>86981887</crc>
+    <date>1993-06-01</date>
+    <publisher>Sculptured Software, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1555-1.jpg</cover>
+    <api_id>1555</api_id>
+  </Game>
+  <Game>
+    <name>Chessmaster, The</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>bc671e15</crc>
+    <date>1991-09-01</date>
+    <publisher>Mindscape</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3756-1.jpg</cover>
+    <api_id>3756</api_id>
+  </Game>
+  <Game>
+    <name>Chester Cheetah - Too Cool to Fool</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>552bf16a</crc>
+    <date>1992-01-01</date>
+    <publisher>Kaneko</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3168-1.jpg</cover>
+    <api_id>3168</api_id>
+  </Game>
+  <Game>
+    <name>Chester Cheetah - Wild Wild Quest</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>557fe962</crc>
+    <date>1994-01-01</date>
+    <publisher>Kaneko</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3169-1.jpg</cover>
+    <api_id>3169</api_id>
+  </Game>
+  <Game>
+    <name>Choplifter III - Rescue &amp; Survive</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1d2eae52</crc>
+    <date>1994-01-01</date>
+    <publisher>Victor Interactive Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1556-1.jpg</cover>
+    <api_id>1556</api_id>
+  </Game>
+  <Game>
+    <name>Chrono Trigger</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2d206bf7</crc>
+    <date>1995-03-11</date>
+    <publisher>Squaresoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1255-1.jpg</cover>
+    <api_id>1255</api_id>
+  </Game>
+  <Game>
+    <name>Chuck Rock</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e237ec45</crc>
+    <date>1992-11-01</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1738-1.jpg</cover>
+    <api_id>1738</api_id>
+  </Game>
+  <Game>
+    <name>Civilization</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>41fdba82</crc>
+    <date>1991-01-01</date>
+    <publisher>MicroProse / Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2548-1.jpg</cover>
+    <api_id>2548</api_id>
+  </Game>
+  <Game>
+    <name>Clay Fighter</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>c814e3c2</crc>
+    <date>1993-11-01</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2851-1.jpg</cover>
+    <api_id>2851</api_id>
+  </Game>
+  <Game>
+    <name>Clay Fighter - Tournament Edition</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>b360f7af</crc>
+    <date>1994-05-01</date>
+    <publisher>Visual Concepts Entertainment, Inc</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1788-1.jpg</cover>
+    <api_id>1788</api_id>
+  </Game>
+  <Game>
+    <name>Clay Fighter 2 - Judgment Clay</name>
+    <players/>
+    <simultaneous/>
+    <crc>20b5c364</crc>
+    <date>1994</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover/>
+  </Game>
+  <Game>
+    <name>Claymates</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>7ad5ccac</crc>
+    <date>1993-11-20</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1740-1.jpg</cover>
+    <api_id>1740</api_id>
+  </Game>
+  <Game>
+    <name>Cliffhanger</name>
+    <players/>
+    <simultaneous/>
+    <crc>12f8a26c</crc>
+    <date>1993-11-01</date>
+    <publisher>Sony</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2853-1.jpg</cover>
+    <api_id>2853</api_id>
+  </Game>
+  <Game>
+    <name>Clue</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a4fbe827</crc>
+    <date>1992-05-13</date>
+    <publisher>Hasbro Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1789-1.jpg</cover>
+    <api_id>1789</api_id>
+  </Game>
+  <Game>
+    <name>College Football USA '97 - The Road to New Orleans</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>a27940c1</crc>
+    <date>1996-01-01</date>
+    <publisher>EA Sports</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3541-1.jpg</cover>
+    <api_id>3541</api_id>
+  </Game>
+  <Game>
+    <name>College Slam</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>ce842c6d</crc>
+    <date>1996-01-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3542-1.jpg</cover>
+    <api_id>3542</api_id>
+  </Game>
+  <Game>
+    <name>Combatribes, The</name>
+    <players>3</players>
+    <simultaneous>0</simultaneous>
+    <crc>9304044a</crc>
+    <date>1990-06-01</date>
+    <publisher>American Technos Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1790-1.jpg</cover>
+    <api_id>1790</api_id>
+  </Game>
+  <Game>
+    <name>Congo's Caper</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>8a24fba8</crc>
+    <date>1992-12-18</date>
+    <publisher>Data East</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/280-1.jpg</cover>
+    <api_id>280</api_id>
+  </Game>
+  <Game>
+    <name>Contra III - The Alien Wars</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>84da7cfe</crc>
+    <date>1992-04-06</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/122-1.jpg</cover>
+    <api_id>122</api_id>
+  </Game>
+  <Game>
+    <name>Cool Spot</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>44e60e58</crc>
+    <date>1993-12-10</date>
+    <publisher>Virgin Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3086-1.jpg</cover>
+    <api_id>3086</api_id>
+  </Game>
+  <Game>
+    <name>Cool World</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>0730c37c</crc>
+    <date>1992-01-01</date>
+    <publisher>Ocean Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2860-1.jpg</cover>
+    <api_id>2860</api_id>
+  </Game>
+  <Game>
+    <name>Cutthroat Island</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>19ea457b</crc>
+    <date>1995-10-07</date>
+    <publisher>Acclaim Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1743-1.jpg</cover>
+    <api_id>1743</api_id>
+  </Game>
+  <Game>
+    <name>Cyber Spin</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>44018650</crc>
+    <date>1992-03-19</date>
+    <publisher>Takuyo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1791-1.jpg</cover>
+    <api_id>1791</api_id>
+  </Game>
+  <Game>
+    <name>Cybernator</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>4dfa05b3</crc>
+    <date>1992-12-18</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1557-1.jpg</cover>
+    <api_id>1557</api_id>
+  </Game>
+  <Game>
+    <name>D-Force</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>24230807</crc>
+    <date>1991-12-20</date>
+    <publisher>Asmik Ace Entertainment Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1793-1.jpg</cover>
+    <api_id>1793</api_id>
+  </Game>
+  <Game>
+    <name>Daffy Duck - The Marvin Missions</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>5f02a044</crc>
+    <date>1993-10-01</date>
+    <publisher>Sunsoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/283-2.jpg</cover>
+    <api_id>283</api_id>
+  </Game>
+  <Game>
+    <name>Darius Twin</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>c5341764</crc>
+    <date>1991-03-29</date>
+    <publisher>Taito</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1744-1.jpg</cover>
+    <api_id>1744</api_id>
+  </Game>
+  <Game>
+    <name>David Crane's Amazing Tennis</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>caad18dc</crc>
+    <date>1992-10-07</date>
+    <publisher>Absolute Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1745-1.jpg</cover>
+    <api_id>1745</api_id>
+  </Game>
+  <Game>
+    <name>Daze Before Christmas</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>59909eb5</crc>
+    <date>1994-10-07</date>
+    <publisher>Sunsoft</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1746-1.jpg</cover>
+    <api_id>1746</api_id>
+  </Game>
+  <Game>
+    <name>Death and Return of Superman, The</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>a567957c</crc>
+    <date>1995-01-01</date>
+    <publisher>SunSoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1747-1.jpg</cover>
+    <api_id>1747</api_id>
+  </Game>
+  <Game>
+    <name>Demolition Man</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>8afe2f91</crc>
+    <date>1995-03-01</date>
+    <publisher>Acclaim, Virgin Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1748-1.jpg</cover>
+    <api_id>1748</api_id>
+  </Game>
+  <Game>
+    <name>Demon's Crest</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e8236ad2</crc>
+    <date>1994-11-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1577-1.jpg</cover>
+    <api_id>1577</api_id>
+  </Game>
+  <Game>
+    <name>Dennis the Menace</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>8ee7faa5</crc>
+    <date>1993-12-01</date>
+    <publisher>Ocean Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1749-1.jpg</cover>
+    <api_id>1749</api_id>
+  </Game>
+  <Game>
+    <name>Desert Strike - Return to the Gulf</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>4ce26787</crc>
+    <date>1992-01-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3550-1.jpg</cover>
+    <api_id>3550</api_id>
+  </Game>
+  <Game>
+    <name>Dig &amp; Spike Volleyball</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>954340f8</crc>
+    <date>1993-01-01</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3552-1.png</cover>
+    <api_id>3552</api_id>
+  </Game>
+  <Game>
+    <name>Dino City</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>94152717</crc>
+    <date>1992-07-17</date>
+    <publisher>Irem</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/42076-1.jpg</cover>
+    <api_id>42076</api_id>
+  </Game>
+  <Game>
+    <name>Dino Dini's Soccer!</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>dbf4a8ab</crc>
+    <date>1994-10-07</date>
+    <publisher>Virgin Gamers</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1753-1.png</cover>
+    <api_id>1753</api_id>
+  </Game>
+  <Game>
+    <name>Dirt Racer</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>0354f4b1</crc>
+    <date>1995-01-01</date>
+    <publisher>Elite</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1754-1.jpg</cover>
+    <api_id>1754</api_id>
+  </Game>
+  <Game>
+    <name>Dirt Trax FX</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>61a86c7f</crc>
+    <date>1995-06-01</date>
+    <publisher>Acclaim Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1755-1.jpg</cover>
+    <api_id>1755</api_id>
+  </Game>
+  <Game>
+    <name>Donkey Kong Country</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>0e204fbd</crc>
+    <date>1994-11-21</date>
+    <publisher>Nintendo</publisher>
+    <region>USA) (Competition Edition</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/131-2.jpg</cover>
+    <api_id>131</api_id>
+  </Game>
+  <Game>
+    <name>Donkey Kong Country</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>762af827</crc>
+    <date>1994-11-21</date>
+    <publisher>Nintendo</publisher>
+    <region>USA) (Competition Edition</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/131-2.jpg</cover>
+    <api_id>131</api_id>
+  </Game>
+  <Game>
+    <name>Donkey Kong Country 2 - Diddy's Kong Quest</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>4e2d90f4</crc>
+    <date>1995-11-20</date>
+    <publisher>Nintendo</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1525-1.jpg</cover>
+    <api_id>1525</api_id>
+  </Game>
+  <Game>
+    <name>Donkey Kong Country 3 - Dixie Kong's Double Trouble!</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>448eec19</crc>
+    <date>1996-11-22</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1526-1.jpg</cover>
+    <api_id>1526</api_id>
+  </Game>
+  <Game>
+    <name>Doom</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>09e85ea6</crc>
+    <date>1995-09-01</date>
+    <publisher>Williams Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2880-1.jpg</cover>
+    <api_id>2880</api_id>
+  </Game>
+  <Game>
+    <name>Doom Troopers</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>1889feef</crc>
+    <date>1995-11-01</date>
+    <publisher>Playmates</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1580-1.jpg</cover>
+    <api_id>1580</api_id>
+  </Game>
+  <Game>
+    <name>Doomsday Warrior</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>ceeb7c32</crc>
+    <date>1992-01-01</date>
+    <publisher>Renovation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3173-1.jpg</cover>
+    <api_id>3173</api_id>
+  </Game>
+  <Game>
+    <name>Double Dragon V - The Shadow Falls</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>98a96ae8</crc>
+    <date>1995-08-05</date>
+    <publisher>Tradewest</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1798-1.jpg</cover>
+    <api_id>1798</api_id>
+  </Game>
+  <Game>
+    <name>Dragon - The Bruce Lee Story</name>
+    <players>3</players>
+    <simultaneous>0</simultaneous>
+    <crc>407c5c24</crc>
+    <date>1995-07-05</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3197-1.jpg</cover>
+    <api_id>3197</api_id>
+  </Game>
+  <Game>
+    <name>Dragon View</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>ab893412</crc>
+    <date>1994-08-26</date>
+    <publisher>KEMCO</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1581-1.jpg</cover>
+    <api_id>1581</api_id>
+  </Game>
+  <Game>
+    <name>Dragon's Lair</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>24ffe7fd</crc>
+    <date>1993-01-01</date>
+    <publisher>Cinematronics</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3196-1.jpg</cover>
+    <api_id>3196</api_id>
+  </Game>
+  <Game>
+    <name>Drakkhen</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7dae5c2a</crc>
+    <date>1991-09-01</date>
+    <publisher>Infogrames</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1759-1.jpg</cover>
+    <api_id>1759</api_id>
+  </Game>
+  <Game>
+    <name>Dream TV</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>ab5a9e40</crc>
+    <date>1993-10-01</date>
+    <publisher>Triffix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1907-1.jpg</cover>
+    <api_id>1907</api_id>
+  </Game>
+  <Game>
+    <name>Duel, The - Test Drive II</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>ba093e24</crc>
+    <date>1992-12-01</date>
+    <publisher>Accolade</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3759-1.jpg</cover>
+    <api_id>3759</api_id>
+  </Game>
+  <Game>
+    <name>Dungeon Master</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0dfd9ceb</crc>
+    <date>1993-06-01</date>
+    <publisher>FLT Games</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1582-1.jpg</cover>
+    <api_id>1582</api_id>
+  </Game>
+  <Game>
+    <name>E.V.O. - Search for Eden</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>dd49911e</crc>
+    <date>1992-12-28</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1909-1.jpg</cover>
+    <api_id>1909</api_id>
+  </Game>
+  <Game>
+    <name>Earth Defense Force</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ca8ff946</crc>
+    <date>1991-10-25</date>
+    <publisher>Jaleco Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2667-1.jpg</cover>
+    <api_id>2667</api_id>
+  </Game>
+  <Game>
+    <name>EarthBound</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>dc9bb451</crc>
+    <date>1994-08-27</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1583-1.png</cover>
+    <api_id>1583</api_id>
+  </Game>
+  <Game>
+    <name>Earthworm Jim</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3a4a47eb</crc>
+    <date>1994-08-02</date>
+    <publisher>Playmates Interactive Entertainment, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/997-2.jpg</cover>
+    <api_id>997</api_id>
+  </Game>
+  <Game>
+    <name>Earthworm Jim 2</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>393de197</crc>
+    <date>1996-01-25</date>
+    <publisher>Playmates</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2896-1.jpg</cover>
+    <api_id>2896</api_id>
+  </Game>
+  <Game>
+    <name>Eek! The Cat</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>216f2fc7</crc>
+    <date>1994-10-07</date>
+    <publisher>Ocean Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1910-1.jpg</cover>
+    <api_id>1910</api_id>
+  </Game>
+  <Game>
+    <name>Elite Soccer</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>62abaee1</crc>
+    <date>1994-06-17</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3562-1.png</cover>
+    <api_id>3562</api_id>
+  </Game>
+  <Game>
+    <name>Emmitt Smith Football</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>09c3c0ef</crc>
+    <date>1995-01-01</date>
+    <publisher>JVC</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3563-1.jpg</cover>
+    <api_id>3563</api_id>
+  </Game>
+  <Game>
+    <name>Equinox</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>96a4d1c0</crc>
+    <date>1994-03-02</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1911-1.jpg</cover>
+    <api_id>1911</api_id>
+  </Game>
+  <Game>
+    <name>ESPN Baseball Tonight</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>8606d69b</crc>
+    <date>1994-05-01</date>
+    <publisher>Sony</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3198-1.jpg</cover>
+    <api_id>3198</api_id>
+  </Game>
+  <Game>
+    <name>ESPN National Hockey Night</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>75058ede</crc>
+    <date>1994-01-01</date>
+    <publisher>Sony</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3564-1.png</cover>
+    <api_id>3564</api_id>
+  </Game>
+  <Game>
+    <name>ESPN Speedworld</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>c2cff05a</crc>
+    <date>1994-01-01</date>
+    <publisher>Sony</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3565-1.jpg</cover>
+    <api_id>3565</api_id>
+  </Game>
+  <Game>
+    <name>ESPN Sunday Night NFL</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>26849f90</crc>
+    <date>1994-01-01</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3566-1.png</cover>
+    <api_id>3566</api_id>
+  </Game>
+  <Game>
+    <name>Exertainment Mountain Bike Rally &amp; Speed Racer</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ee5e1906</crc>
+    <date>1994-10-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/36681-1.png</cover>
+    <api_id>36681</api_id>
+  </Game>
+  <Game>
+    <name>Exertainment Mountain Bike Rally</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>e6ede101</crc>
+    <date>1994</date>
+    <publisher/>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/31476-1.jpg</cover>
+    <api_id>31476</api_id>
+  </Game>
+  <Game>
+    <name>Extra Innings</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>440a4250</crc>
+    <date>1991-01-01</date>
+    <publisher>Sony</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3568-1.png</cover>
+    <api_id>3568</api_id>
+  </Game>
+  <Game>
+    <name>Eye of the Beholder</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>20143571</crc>
+    <date>1994-03-18</date>
+    <publisher>Strategic Simulations, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/284-1.jpg</cover>
+    <api_id>284</api_id>
+  </Game>
+  <Game>
+    <name>F-Zero</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>aa0e31de</crc>
+    <date>1991-08-23</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/43448-1.jpg</cover>
+    <api_id>43448</api_id>
+  </Game>
+  <Game>
+    <name>F1 Pole Position</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>b3da1b1d</crc>
+    <date>1993-01-01</date>
+    <publisher>Ubisoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3569-1.jpg</cover>
+    <api_id>3569</api_id>
+  </Game>
+  <Game>
+    <name>F1 Pole Position 2</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>83fc0f0c</crc>
+    <date>1993-12-24</date>
+    <publisher>Ubisoft</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3570-1.jpg</cover>
+    <api_id>3570</api_id>
+  </Game>
+  <Game>
+    <name>F1 ROC - Race of Champions</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2a069989</crc>
+    <date>1992-02-21</date>
+    <publisher>Seta Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3602-1.png</cover>
+    <api_id>3602</api_id>
+  </Game>
+  <Game>
+    <name>F1 ROC II - Race of Champions</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3447609e</crc>
+    <date>1993-03-05</date>
+    <publisher>Seta</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3601-1.png</cover>
+    <api_id>3601</api_id>
+  </Game>
+  <Game>
+    <name>F1 World Championship Edition</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>7ba8fc78</crc>
+    <date>1995-01-01</date>
+    <publisher>Acclaim</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/31755-1.jpg</cover>
+    <api_id>31755</api_id>
+  </Game>
+  <Game>
+    <name>Faceball 2000</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>8d4df815</crc>
+    <date>1992-01-01</date>
+    <publisher>Bullet Proof Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3603-1.jpg</cover>
+    <api_id>3603</api_id>
+  </Game>
+  <Game>
+    <name>Family Dog</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>1b53c15a</crc>
+    <date>1992-01-01</date>
+    <publisher>Malibu Games</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3604-1.png</cover>
+    <api_id>3604</api_id>
+  </Game>
+  <Game>
+    <name>Family Feud</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>0c664b71</crc>
+    <date>1993-01-01</date>
+    <publisher>Gametek</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3605-1.png</cover>
+    <api_id>3605</api_id>
+  </Game>
+  <Game>
+    <name>Fatal Fury</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>c67257d0</crc>
+    <date>1991-12-20</date>
+    <publisher>SNk</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/974-2.jpg</cover>
+    <api_id>974</api_id>
+  </Game>
+  <Game>
+    <name>Fatal Fury 2</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a26ebfef</crc>
+    <date>1993-11-26</date>
+    <publisher>Takara</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2863-1.jpg</cover>
+    <api_id>2863</api_id>
+  </Game>
+  <Game>
+    <name>Fatal Fury Special</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>93935bee</crc>
+    <date>1994-07-29</date>
+    <publisher>Takara</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2858-1.jpg</cover>
+    <api_id>2858</api_id>
+  </Game>
+  <Game>
+    <name>FIFA 98 - Road to World Cup</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>5e4f4856</crc>
+    <date>1997-01-01</date>
+    <publisher>EA Sports</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3608-1.png</cover>
+    <api_id>3608</api_id>
+  </Game>
+  <Game>
+    <name>FIFA International Soccer</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>56296426</crc>
+    <date>1994-01-01</date>
+    <publisher>Laguna</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3609-1.jpg</cover>
+    <api_id>3609</api_id>
+  </Game>
+  <Game>
+    <name>FIFA Soccer 96</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>7566347d</crc>
+    <date>1995-11-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3610-1.jpg</cover>
+    <api_id>3610</api_id>
+  </Game>
+  <Game>
+    <name>FIFA Soccer 97 - Gold Edition</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>9cdbb2f8</crc>
+    <date>1996-01-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3611-1.jpg</cover>
+    <api_id>3611</api_id>
+  </Game>
+  <Game>
+    <name>Fighter's History</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>3d17f6ea</crc>
+    <date>1994-05-27</date>
+    <publisher>Data East</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1912-1.png</cover>
+    <api_id>1912</api_id>
+  </Game>
+  <Game>
+    <name>Final Fantasy - Mystic Quest</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2c52c792</crc>
+    <date>1992-10-05</date>
+    <publisher>Squaresoft</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1602-1.jpg</cover>
+    <api_id>1602</api_id>
+  </Game>
+  <Game>
+    <name>Final Fantasy II</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>23084fcd</crc>
+    <date>1991-11-01</date>
+    <publisher>Squaresoft</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1286-2.jpg</cover>
+    <api_id>1286</api_id>
+  </Game>
+  <Game>
+    <name>Final Fantasy III</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c0fa0464</crc>
+    <date>1994-04-02</date>
+    <publisher>Squaresoft</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/83-1.jpg</cover>
+    <api_id>83</api_id>
+  </Game>
+  <Game>
+    <name>Final Fight</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>4cab21db</crc>
+    <date>1991-09-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1913-1.jpg</cover>
+    <api_id>1913</api_id>
+  </Game>
+  <Game>
+    <name>Final Fight 2</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>8c37ff55</crc>
+    <date>1993-05-22</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1763-1.png</cover>
+    <api_id>1763</api_id>
+  </Game>
+  <Game>
+    <name>Final Fight 3</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a916e708</crc>
+    <date>1995-12-22</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1914-1.jpg</cover>
+    <api_id>1914</api_id>
+  </Game>
+  <Game>
+    <name>Final Fight Guy</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>bc1ae3c2</crc>
+    <date>1992-03-20</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3613-1.png</cover>
+    <api_id>3613</api_id>
+  </Game>
+  <Game>
+    <name>Fire Striker</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>e500c7ba</crc>
+    <date>1994-10-14</date>
+    <publisher>DTMC</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3618-1.png</cover>
+    <api_id>3618</api_id>
+  </Game>
+  <Game>
+    <name>Firemen, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>def665af</crc>
+    <date>1995-03-15</date>
+    <publisher>HUMAN</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/44784-1.jpg</cover>
+    <api_id>44784</api_id>
+  </Game>
+  <Game>
+    <name>Firepower 2000</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>327416d4</crc>
+    <date>1992-11-13</date>
+    <publisher>Sunsoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3617-1.jpg</cover>
+    <api_id>3617</api_id>
+  </Game>
+  <Game>
+    <name>First Samurai</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>4f0a1e2a</crc>
+    <date>1991-10-07</date>
+    <publisher>Image Works</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1915-1.jpg</cover>
+    <api_id>1915</api_id>
+  </Game>
+  <Game>
+    <name>Flashback - The Quest for Identity</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1e6aceba</crc>
+    <date>1993-12-22</date>
+    <publisher>Sunsoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3199-1.jpg</cover>
+    <api_id>3199</api_id>
+  </Game>
+  <Game>
+    <name>Flintstones, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3e7b51e0</crc>
+    <date>1995-02-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3761-1.png</cover>
+    <api_id>3761</api_id>
+  </Game>
+  <Game>
+    <name>Flintstones, The - The Treasure of Sierra Madrock</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>594f5cc6</crc>
+    <date>1994-03-01</date>
+    <publisher>Taito</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3762-1.png</cover>
+    <api_id>3762</api_id>
+  </Game>
+  <Game>
+    <name>Football Fury</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>729a5524</crc>
+    <date>1993-01-01</date>
+    <publisher>American Sammy</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3619-1.jpg</cover>
+    <api_id>3619</api_id>
+  </Game>
+  <Game>
+    <name>Foreman For Real</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>5fa4d051</crc>
+    <date>1995-01-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3620-1.png</cover>
+    <api_id>3620</api_id>
+  </Game>
+  <Game>
+    <name>Frank Thomas Big Hurt Baseball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>21239dda</crc>
+    <date>1995-01-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3621-1.jpg</cover>
+    <api_id>3621</api_id>
+  </Game>
+  <Game>
+    <name>Frantic Flea</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>ffa8d1ff</crc>
+    <date>1996-04-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1765-1.jpg</cover>
+    <api_id>1765</api_id>
+  </Game>
+  <Game>
+    <name>Frogger</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2488b8f2</crc>
+    <date>1998-01-01</date>
+    <publisher>Majesco Games</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3622-1.jpg</cover>
+    <api_id>3622</api_id>
+  </Game>
+  <Game>
+    <name>Full Throttle - All-American Racing</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2a4a53ca</crc>
+    <date>1994-01-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3625-1.png</cover>
+    <api_id>3625</api_id>
+  </Game>
+  <Game>
+    <name>Fun 'n Games</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>5d6deac7</crc>
+    <date>1994-01-01</date>
+    <publisher>Tradewest</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3626-1.jpg</cover>
+    <api_id>3626</api_id>
+  </Game>
+  <Game>
+    <name>Gemfire</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>ee801a54</crc>
+    <date>1992-01-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3629-1.jpg</cover>
+    <api_id>3629</api_id>
+  </Game>
+  <Game>
+    <name>Genghis Khan II - Clan of the Gray Wolf</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>d7875512</crc>
+    <date>1992-01-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3630-1.jpg</cover>
+    <api_id>3630</api_id>
+  </Game>
+  <Game>
+    <name>George Foreman's KO Boxing</name>
+    <players>2</players>
+    <simultaneous/>
+    <crc>15194fc9</crc>
+    <date>1992-01-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3631-1.png</cover>
+    <api_id>3631</api_id>
+  </Game>
+  <Game>
+    <name>Ghoul Patrol</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>ea16b5a2</crc>
+    <date>1994-11-01</date>
+    <publisher>LucasArts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1917-1.jpg</cover>
+    <api_id>1917</api_id>
+  </Game>
+  <Game>
+    <name>Goal!</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>935ea22c</crc>
+    <date>1992-12-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3763-1.jpg</cover>
+    <api_id>3763</api_id>
+  </Game>
+  <Game>
+    <name>Gods</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>6779970f</crc>
+    <date>1992-01-01</date>
+    <publisher>Mindscape Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3633-1.jpg</cover>
+    <api_id>3633</api_id>
+  </Game>
+  <Game>
+    <name>Goof Troop</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>4aafa462</crc>
+    <date>1993-07-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3200-1.jpg</cover>
+    <api_id>3200</api_id>
+  </Game>
+  <Game>
+    <name>GP-1</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>14bbc357</crc>
+    <date>1993-01-01</date>
+    <publisher>Atlus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3635-1.jpg</cover>
+    <api_id>3635</api_id>
+  </Game>
+  <Game>
+    <name>GP-1 - Part II</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a9014e12</crc>
+    <date>1994-01-01</date>
+    <publisher>Atlus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3636-1.jpg</cover>
+    <api_id>3636</api_id>
+  </Game>
+  <Game>
+    <name>Gradius III</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>cd973979</crc>
+    <date>1991-08-13</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1918-1.jpg</cover>
+    <api_id>1918</api_id>
+  </Game>
+  <Game>
+    <name>Great Circus Mystery Starring Mickey &amp; Minnie, The</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>1903ea89</crc>
+    <date>1994-10-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2786-1.jpg</cover>
+    <api_id>2786</api_id>
+  </Game>
+  <Game>
+    <name>Great Waldo Search, The</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>eb49f246</crc>
+    <date>1993-06-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3764-1.jpg</cover>
+    <api_id>3764</api_id>
+  </Game>
+  <Game>
+    <name>GunForce - Battle Fire Engulfed Terror Island</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6f5c5dc0</crc>
+    <date>1992-01-01</date>
+    <publisher>Irem</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3637-1.png</cover>
+    <api_id>3637</api_id>
+  </Game>
+  <Game>
+    <name>Hagane - The Final Conflict</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8e0a7034</crc>
+    <date>1994-11-18</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1919-1.jpg</cover>
+    <api_id>1919</api_id>
+  </Game>
+  <Game>
+    <name>HAL's Hole in One Golf</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>58752baf</crc>
+    <date>1991-02-23</date>
+    <publisher>HAL</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3765-1.png</cover>
+    <api_id>3765</api_id>
+  </Game>
+  <Game>
+    <name>Hammerlock Wrestling</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>3d2352ea</crc>
+    <date>1994-10-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3639-1.png</cover>
+    <api_id>3639</api_id>
+  </Game>
+  <Game>
+    <name>HardBall III</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f3589b15</crc>
+    <date>1994-06-01</date>
+    <publisher>Accolade</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3640-1.jpg</cover>
+    <api_id>3640</api_id>
+  </Game>
+  <Game>
+    <name>Harley's Humongous Adventure</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>91e0c960</crc>
+    <date>1993-02-05</date>
+    <publisher>Hi Tech Expressions</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/43089-1.jpg</cover>
+    <api_id>43089</api_id>
+  </Game>
+  <Game>
+    <name>Harvest Moon</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f829129e</crc>
+    <date>1996-08-09</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1921-1.jpg</cover>
+    <api_id>1921</api_id>
+  </Game>
+  <Game>
+    <name>Head-On Soccer</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>60dc3634</crc>
+    <date>1995-09-01</date>
+    <publisher>U.S. Gold Ltd.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3766-1.jpg</cover>
+    <api_id>3766</api_id>
+  </Game>
+  <Game>
+    <name>Hebereke's Popoitto</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>0ce626ba</crc>
+    <date>1993-10-07</date>
+    <publisher>Sunsoft</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1922-1.jpg</cover>
+    <api_id>1922</api_id>
+  </Game>
+  <Game>
+    <name>Hebereke's Popoon</name>
+    <players/>
+    <simultaneous/>
+    <crc>7a313722</crc>
+    <date>1994</date>
+    <publisher>SunSoft</publisher>
+    <region>Europe</region>
+    <cover/>
+  </Game>
+  <Game>
+    <name>Hit the Ice</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>ec13477e</crc>
+    <date>1993-02-01</date>
+    <publisher>Taito Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3787-1.jpg</cover>
+    <api_id>3787</api_id>
+  </Game>
+  <Game>
+    <name>Home Alone</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>07c494b1</crc>
+    <date>1991-12-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2843-1.jpg</cover>
+    <api_id>2843</api_id>
+  </Game>
+  <Game>
+    <name>Home Alone 2 - Lost in New York</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d19165d9</crc>
+    <date>1992-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3788-1.jpg</cover>
+    <api_id>3788</api_id>
+  </Game>
+  <Game>
+    <name>Home Improvement</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>fa698c31</crc>
+    <date>1994-01-01</date>
+    <publisher>Absolute Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1923-1.jpg</cover>
+    <api_id>1923</api_id>
+  </Game>
+  <Game>
+    <name>Hook</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0c572ef0</crc>
+    <date>1992-07-17</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3201-1.png</cover>
+    <api_id>3201</api_id>
+  </Game>
+  <Game>
+    <name>Humans, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d2af01d4</crc>
+    <date>1993-01-01</date>
+    <publisher>Gametek</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3789-1.jpg</cover>
+    <api_id>3789</api_id>
+  </Game>
+  <Game>
+    <name>Hungry Dinosaurs</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>5c4b2544</crc>
+    <date>1994-10-19</date>
+    <publisher>Mahou</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5519-1.jpg</cover>
+    <api_id>5519</api_id>
+  </Game>
+  <Game>
+    <name>Hunt for Red October, The</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>c796e830</crc>
+    <date>1990-10-07</date>
+    <publisher>Hi-Tech Expressions</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1324-2.jpg</cover>
+    <api_id>1324</api_id>
+  </Game>
+  <Game>
+    <name>Hurricanes</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>42ff4f08</crc>
+    <date>1994-12-01</date>
+    <publisher>U.S. Gold Ltd.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3790-1.jpg</cover>
+    <api_id>3790</api_id>
+  </Game>
+  <Game>
+    <name>Hyper V-Ball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>7d179e21</crc>
+    <date>1995-12-12</date>
+    <publisher>Video System</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1983-1.jpg</cover>
+    <api_id>1983</api_id>
+  </Game>
+  <Game>
+    <name>HyperZone</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c95b4129</crc>
+    <date>1991-08-31</date>
+    <publisher>HAL Laboratory</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1984-1.jpg</cover>
+    <api_id>1984</api_id>
+  </Game>
+  <Game>
+    <name>Ignition Factor, The</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>ee441564</crc>
+    <date>1994-11-11</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1985-1.jpg</cover>
+    <api_id>1985</api_id>
+  </Game>
+  <Game>
+    <name>Illusion of Gaia</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1c3848c0</crc>
+    <date>1993-11-27</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1986-1.jpg</cover>
+    <api_id>1986</api_id>
+  </Game>
+  <Game>
+    <name>Imperium</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2624f8bd</crc>
+    <date>1992-01-01</date>
+    <publisher>Vic Tokai</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1987-1.jpg</cover>
+    <api_id>1987</api_id>
+  </Game>
+  <Game>
+    <name>Incantation</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d0ff7e9f</crc>
+    <date>1996-12-01</date>
+    <publisher>Titus Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3792-2.jpg</cover>
+    <api_id>3792</api_id>
+  </Game>
+  <Game>
+    <name>Incredible Crash Dummies, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0b6209ba</crc>
+    <date>1993-01-01</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3793-1.jpg</cover>
+    <api_id>3793</api_id>
+  </Game>
+  <Game>
+    <name>Incredible Hulk, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>36b5a429</crc>
+    <date>1994-08-01</date>
+    <publisher>U.S. Gold</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2783-1.jpg</cover>
+    <api_id>2783</api_id>
+  </Game>
+  <Game>
+    <name>Indiana Jones' Greatest Adventures</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>70da6bb8</crc>
+    <date>1994-10-11</date>
+    <publisher>JVC</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1989-1.jpg</cover>
+    <api_id>1989</api_id>
+  </Game>
+  <Game>
+    <name>Inindo - Way of the Ninja</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>543f3327</crc>
+    <date>1991-10-07</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1990-1.jpg</cover>
+    <api_id>1990</api_id>
+  </Game>
+  <Game>
+    <name>Inspector Gadget</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>4ce2b818</crc>
+    <date>1993-12-01</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1991-2.jpg</cover>
+    <api_id>1991</api_id>
+  </Game>
+  <Game>
+    <name>International Superstar Soccer</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6cd568a9</crc>
+    <date>1995-06-01</date>
+    <publisher>Konami</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3794-1.jpg</cover>
+    <api_id>3794</api_id>
+  </Game>
+  <Game>
+    <name>International Superstar Soccer</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>49627238</crc>
+    <date>1995-06-01</date>
+    <publisher>Konami</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3794-1.jpg</cover>
+    <api_id>3794</api_id>
+  </Game>
+  <Game>
+    <name>International Superstar Soccer Deluxe</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>0a20e602</crc>
+    <date>1995-09-22</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3795-2.jpg</cover>
+    <api_id>3795</api_id>
+  </Game>
+  <Game>
+    <name>International Tennis Tour</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>ad3cd5e6</crc>
+    <date>1993-03-23</date>
+    <publisher>Taito</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3796-1.jpg</cover>
+    <api_id>3796</api_id>
+  </Game>
+  <Game>
+    <name>Irem Skins Game, The</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>b95ddc44</crc>
+    <date>1992-10-01</date>
+    <publisher>Irem</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3797-1.png</cover>
+    <api_id>3797</api_id>
+  </Game>
+  <Game>
+    <name>Itchy &amp; Scratchy Game, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>95b65dfe</crc>
+    <date>1995-03-01</date>
+    <publisher>Acclaim Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2782-1.jpg</cover>
+    <api_id>2782</api_id>
+  </Game>
+  <Game>
+    <name>Izzy's Quest for the Olympic Rings</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>e9bb68c7</crc>
+    <date>1995-11-01</date>
+    <publisher>U.S. Gold Ltd.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3798-1.jpg</cover>
+    <api_id>3798</api_id>
+  </Game>
+  <Game>
+    <name>J.R.R. Tolkien's The Lord of the Rings - Volume 1</name>
+    <players>4+</players>
+    <simultaneous>1</simultaneous>
+    <crc>cd2150c8</crc>
+    <date>1994-10-01</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3215-1.jpg</cover>
+    <api_id>3215</api_id>
+  </Game>
+  <Game>
+    <name>Jack Nicklaus Golf</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>9abc58e2</crc>
+    <date>1992-01-01</date>
+    <publisher>Tradewest</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3799-1.jpg</cover>
+    <api_id>3799</api_id>
+  </Game>
+  <Game>
+    <name>James Bond Jr</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>69c2f850</crc>
+    <date>1992-10-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3800-1.jpg</cover>
+    <api_id>3800</api_id>
+  </Game>
+  <Game>
+    <name>Jammit</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>7bddd73f</crc>
+    <date>1994-01-01</date>
+    <publisher>GTE Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3802-1.jpg</cover>
+    <api_id>3802</api_id>
+  </Game>
+  <Game>
+    <name>Jelly Boy</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>f8c72a24</crc>
+    <date>1995-03-01</date>
+    <publisher>Ocean</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1770-2.jpg</cover>
+    <api_id>1770</api_id>
+  </Game>
+  <Game>
+    <name>Jeopardy!</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>65bf3a7e</crc>
+    <date>1992-12-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/285-1.jpg</cover>
+    <api_id>285</api_id>
+  </Game>
+  <Game>
+    <name>Jeopardy! - Deluxe Edition</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6301060c</crc>
+    <date>1994-06-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3803-1.png</cover>
+    <api_id>3803</api_id>
+  </Game>
+  <Game>
+    <name>Jeopardy! - Sports Edition</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>bda7de29</crc>
+    <date>1994-05-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3804-1.jpg</cover>
+    <api_id>3804</api_id>
+  </Game>
+  <Game>
+    <name>Jetsons, The - Invasion of the Planet Pirates</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3e3073ce</crc>
+    <date>1994-01-01</date>
+    <publisher>Taito Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3805-1.jpg</cover>
+    <api_id>3805</api_id>
+  </Game>
+  <Game>
+    <name>Jim Lee's WildC.A.T.S - Covert Action Teams</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>10c6f5ad</crc>
+    <date>1995-11-17</date>
+    <publisher>Playmates</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3808-1.png</cover>
+    <api_id>3808</api_id>
+  </Game>
+  <Game>
+    <name>Jim Power - The Lost Dimension in 3D</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c469f8f0</crc>
+    <date>1993-12-10</date>
+    <publisher>Electro Brain</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1994-1.jpg</cover>
+    <api_id>1994</api_id>
+  </Game>
+  <Game>
+    <name>Jimmy Connors Pro Tennis Tour</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>913f1555</crc>
+    <date>1993-10-29</date>
+    <publisher>Ubisoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1995-1.jpg</cover>
+    <api_id>1995</api_id>
+  </Game>
+  <Game>
+    <name>Jimmy Houston's Bass Tournament U.S.A.</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e7e488d5</crc>
+    <date>1995-01-01</date>
+    <publisher>Sammy</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3809-1.jpg</cover>
+    <api_id>3809</api_id>
+  </Game>
+  <Game>
+    <name>Joe &amp; Mac</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>3a2b6167</crc>
+    <date>1992-01-01</date>
+    <publisher>Data East</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/17855-1.png</cover>
+    <api_id>17855</api_id>
+  </Game>
+  <Game>
+    <name>Joe &amp; Mac 2 - Lost in the Tropics</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>0c3b4201</crc>
+    <date>1994-02-18</date>
+    <publisher>Data East</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1996-1.jpg</cover>
+    <api_id>1996</api_id>
+  </Game>
+  <Game>
+    <name>John Madden Football '93</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>dc5a250b</crc>
+    <date>1992-11-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3810-1.jpg</cover>
+    <api_id>3810</api_id>
+  </Game>
+  <Game>
+    <name>John Madden Football</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>796294c6</crc>
+    <date>1991-11-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2839-1.jpg</cover>
+    <api_id>2839</api_id>
+  </Game>
+  <Game>
+    <name>Judge Dredd</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0a3f0288</crc>
+    <date>1995-10-27</date>
+    <publisher>Acclaim Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/287-1.jpg</cover>
+    <api_id>287</api_id>
+  </Game>
+  <Game>
+    <name>Jungle Book, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3511efb3</crc>
+    <date>1994-08-01</date>
+    <publisher>Virgin</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2872-1.jpg</cover>
+    <api_id>2872</api_id>
+  </Game>
+  <Game>
+    <name>Jungle Strike</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>335487e5</crc>
+    <date>1995-06-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3202-1.jpg</cover>
+    <api_id>3202</api_id>
+  </Game>
+  <Game>
+    <name>Jurassic Park</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8bfde0b7</crc>
+    <date>1993-11-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3203-1.jpg</cover>
+    <api_id>3203</api_id>
+  </Game>
+  <Game>
+    <name>Jurassic Park II - The Chaos Continues</name>
+    <players/>
+    <simultaneous/>
+    <crc>836ee990</crc>
+    <date>1994</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover/>
+  </Game>
+  <Game>
+    <name>Justice League Task Force</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>31cf46d1</crc>
+    <date>1995-10-27</date>
+    <publisher>Acclaim Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1998-1.jpg</cover>
+    <api_id>1998</api_id>
+  </Game>
+  <Game>
+    <name>Kablooey</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>b2592eae</crc>
+    <date>1992-01-01</date>
+    <publisher>Kemco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/288-1.jpg</cover>
+    <api_id>288</api_id>
+  </Game>
+  <Game>
+    <name>Kawasaki Caribbean Challenge</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>37d8ac57</crc>
+    <date>1993-06-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3819-1.jpg</cover>
+    <api_id>3819</api_id>
+  </Game>
+  <Game>
+    <name>Kawasaki Superbike Challenge</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e8ed176e</crc>
+    <date>1995-01-01</date>
+    <publisher>Time Warner Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3820-1.jpg</cover>
+    <api_id>3820</api_id>
+  </Game>
+  <Game>
+    <name>Ken Griffey Jr. Presents Major League Baseball</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>8bf2b589</crc>
+    <date>1994-03-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3821-1.jpg</cover>
+    <api_id>3821</api_id>
+  </Game>
+  <Game>
+    <name>Ken Griffey Jr.'s Winning Run</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>e9b4bd73</crc>
+    <date>1995-06-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3822-1.jpg</cover>
+    <api_id>3822</api_id>
+  </Game>
+  <Game>
+    <name>Kendo Rage</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d1048918</crc>
+    <date>1993-03-12</date>
+    <publisher>SETA</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2000-1.jpg</cover>
+    <api_id>2000</api_id>
+  </Game>
+  <Game>
+    <name>Kevin Keegan's Player Manager</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>fce7bade</crc>
+    <date>1993-01-01</date>
+    <publisher>Imagineer</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1773-1.jpg</cover>
+    <api_id>1773</api_id>
+  </Game>
+  <Game>
+    <name>Kick Off</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>a1306f3b</crc>
+    <date>1993-07-22</date>
+    <publisher>Imagineer</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3823-1.jpg</cover>
+    <api_id>3823</api_id>
+  </Game>
+  <Game>
+    <name>Kick Off 3 - European Challenge</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>1ac7f523</crc>
+    <date>1994-01-01</date>
+    <publisher>Vic Tokai</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3824-1.png</cover>
+    <api_id>3824</api_id>
+  </Game>
+  <Game>
+    <name>Kid Klown in Crazy Chase</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>bd6c8ab1</crc>
+    <date>1994-05-02</date>
+    <publisher>Kemco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3825-1.png</cover>
+    <api_id>3825</api_id>
+  </Game>
+  <Game>
+    <name>Killer Instinct</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>09e9a04e</crc>
+    <date>1995-08-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1254-1.jpg</cover>
+    <api_id>1254</api_id>
+  </Game>
+  <Game>
+    <name>King Arthur &amp; The Knights of Justice</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>615a183b</crc>
+    <date>1995-01-01</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3204-1.jpg</cover>
+    <api_id>3204</api_id>
+  </Game>
+  <Game>
+    <name>King Arthur's World</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>99bd1fe1</crc>
+    <date>1993-03-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3826-1.jpg</cover>
+    <api_id>3826</api_id>
+  </Game>
+  <Game>
+    <name>King of Dragons, The</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>dd505df7</crc>
+    <date>1994-01-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3205-1.jpg</cover>
+    <api_id>3205</api_id>
+  </Game>
+  <Game>
+    <name>King of the Monsters</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>c285c7ff</crc>
+    <date>1992-01-01</date>
+    <publisher>Takara</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3827-1.jpg</cover>
+    <api_id>3827</api_id>
+  </Game>
+  <Game>
+    <name>King of the Monsters 2</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>0b677a37</crc>
+    <date>1994-01-01</date>
+    <publisher>Takara</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3206-1.jpg</cover>
+    <api_id>3206</api_id>
+  </Game>
+  <Game>
+    <name>Kirby Super Star</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>89d0f7dc</crc>
+    <date>1996-09-20</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1315-1.jpg</cover>
+    <api_id>1315</api_id>
+  </Game>
+  <Game>
+    <name>Kirby's Avalanche</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>21e658b8</crc>
+    <date>1995-02-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3207-1.jpg</cover>
+    <api_id>3207</api_id>
+  </Game>
+  <Game>
+    <name>Kirby's Dream Course</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>df8153d9</crc>
+    <date>1995-02-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1774-1.jpg</cover>
+    <api_id>1774</api_id>
+  </Game>
+  <Game>
+    <name>Kirby's Dream Land 3</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>ec8a48f6</crc>
+    <date>1997-11-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3208-1.jpg</cover>
+    <api_id>3208</api_id>
+  </Game>
+  <Game>
+    <name>Knights of the Round</name>
+    <players>3</players>
+    <simultaneous>0</simultaneous>
+    <crc>aaa82126</crc>
+    <date>1991-11-27</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1316-1.jpg</cover>
+    <api_id>1316</api_id>
+  </Game>
+  <Game>
+    <name>Krusty's Super Fun House</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ac5116d9</crc>
+    <date>1992-06-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/289-1.jpg</cover>
+    <api_id>289</api_id>
+  </Game>
+  <Game>
+    <name>Kyle Petty's No Fear Racing</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>aee90a85</crc>
+    <date>1995-04-01</date>
+    <publisher>William's Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3828-1.jpg</cover>
+    <api_id>3828</api_id>
+  </Game>
+  <Game>
+    <name>Lagoon</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d2554270</crc>
+    <date>1991-12-01</date>
+    <publisher>Kemco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1776-1.jpg</cover>
+    <api_id>1776</api_id>
+  </Game>
+  <Game>
+    <name>Lamborghini American Challenge</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>d2fb701b</crc>
+    <date>1993-11-01</date>
+    <publisher>Titus France</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3829-1.jpg</cover>
+    <api_id>3829</api_id>
+  </Game>
+  <Game>
+    <name>Last Action Hero</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>88017df9</crc>
+    <date>1993-10-01</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3209-1.jpg</cover>
+    <api_id>3209</api_id>
+  </Game>
+  <Game>
+    <name>Lawnmower Man, The</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2736b607</crc>
+    <date>1993-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3210-1.jpg</cover>
+    <api_id>3210</api_id>
+  </Game>
+  <Game>
+    <name>Legend</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>0a6dd870</crc>
+    <date>1994-04-01</date>
+    <publisher>Seika</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3248-1.png</cover>
+    <api_id>3248</api_id>
+  </Game>
+  <Game>
+    <name>Legend of the Mystical Ninja, The</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>82479d6a</crc>
+    <date>1994-01-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3211-1.jpg</cover>
+    <api_id>3211</api_id>
+  </Game>
+  <Game>
+    <name>Legend of Zelda, The - A Link to the Past</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>777aac2f</crc>
+    <date>1992-04-13</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1318-1.jpg</cover>
+    <api_id>1318</api_id>
+  </Game>
+  <Game>
+    <name>Lemmings</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>51e3d566</crc>
+    <date>1992-03-01</date>
+    <publisher>Sunsoft</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2832-1.jpg</cover>
+    <api_id>2832</api_id>
+  </Game>
+  <Game>
+    <name>Lemmings 2 - The Tribes</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>df7200c8</crc>
+    <date>1994-11-01</date>
+    <publisher>Psygnosis</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2663-2.jpg</cover>
+    <api_id>2663</api_id>
+  </Game>
+  <Game>
+    <name>Lester the Unlikely</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>1a52fee5</crc>
+    <date>1994-01-01</date>
+    <publisher>DTMC</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3830-1.jpg</cover>
+    <api_id>3830</api_id>
+  </Game>
+  <Game>
+    <name>Lethal Enforcers</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>5aff8cd5</crc>
+    <date>1994-01-03</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3831-1.jpg</cover>
+    <api_id>3831</api_id>
+  </Game>
+  <Game>
+    <name>Lethal Weapon</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>a14c3dbc</crc>
+    <date>1992-12-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1777-1.jpg</cover>
+    <api_id>1777</api_id>
+  </Game>
+  <Game>
+    <name>Liberty or Death</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>75e362a6</crc>
+    <date>1994-01-01</date>
+    <publisher>KOEI</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3832-1.jpg</cover>
+    <api_id>3832</api_id>
+  </Game>
+  <Game>
+    <name>Lion King, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c8fbfaa8</crc>
+    <date>1994-12-08</date>
+    <publisher>Virgin Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3171-1.jpg</cover>
+    <api_id>3171</api_id>
+  </Game>
+  <Game>
+    <name>Lock On</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>84f7e078</crc>
+    <date>1993-10-01</date>
+    <publisher>Vic Tokai</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3212-1.jpg</cover>
+    <api_id>3212</api_id>
+  </Game>
+  <Game>
+    <name>Looney Tunes B-Ball</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>6d3bc96f</crc>
+    <date>1995-02-01</date>
+    <publisher>SunSoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3213-1.jpg</cover>
+    <api_id>3213</api_id>
+  </Game>
+  <Game>
+    <name>Lost Vikings 2</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3aa01dbd</crc>
+    <date>1997-05-01</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3833-2.jpg</cover>
+    <api_id>3833</api_id>
+  </Game>
+  <Game>
+    <name>Lost Vikings, The</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6838be08</crc>
+    <date>1993-04-01</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3216-1.jpg</cover>
+    <api_id>3216</api_id>
+  </Game>
+  <Game>
+    <name>Lucky Luke</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7e2c7143</crc>
+    <date>1997-10-27</date>
+    <publisher>Infogrames</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1779-2.jpg</cover>
+    <api_id>1779</api_id>
+  </Game>
+  <Game>
+    <name>Lufia &amp; The Fortress of Doom</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>5e1aa1a6</crc>
+    <date>1993-12-04</date>
+    <publisher>Taito</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3217-1.jpg</cover>
+    <api_id>3217</api_id>
+  </Game>
+  <Game>
+    <name>Lufia II - Rise of the Sinistrals</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>20f2ac29</crc>
+    <date>1996-08-31</date>
+    <publisher>Natsume</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3218-1.jpg</cover>
+    <api_id>3218</api_id>
+  </Game>
+  <Game>
+    <name>Madden NFL '94</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>8bed5914</crc>
+    <date>1993-10-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3219-1.jpg</cover>
+    <api_id>3219</api_id>
+  </Game>
+  <Game>
+    <name>Madden NFL 95</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>021a3f69</crc>
+    <date>1994-11-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3834-1.jpg</cover>
+    <api_id>3834</api_id>
+  </Game>
+  <Game>
+    <name>Madden NFL 96</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>51a1fe86</crc>
+    <date>1995-11-30</date>
+    <publisher>EA Sports</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/290-1.jpg</cover>
+    <api_id>290</api_id>
+  </Game>
+  <Game>
+    <name>Madden NFL 97</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>abcf026e</crc>
+    <date>1996-10-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/291-1.jpg</cover>
+    <api_id>291</api_id>
+  </Game>
+  <Game>
+    <name>Madden NFL 98</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>cf10cc01</crc>
+    <date>1997-11-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3835-1.jpg</cover>
+    <api_id>3835</api_id>
+  </Game>
+  <Game>
+    <name>Magic Boy</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>ab57a2f9</crc>
+    <date>1996-08-01</date>
+    <publisher>JVC</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3220-1.jpg</cover>
+    <api_id>3220</api_id>
+  </Game>
+  <Game>
+    <name>Magic Sword</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>27325e4d</crc>
+    <date>1992-05-29</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3221-1.jpg</cover>
+    <api_id>3221</api_id>
+  </Game>
+  <Game>
+    <name>Magical Quest Starring Mickey Mouse, The</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>10874c70</crc>
+    <date>1992-12-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1724-1.jpg</cover>
+    <api_id>1724</api_id>
+  </Game>
+  <Game>
+    <name>Manchester United Championship Soccer</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>8d2596a7</crc>
+    <date>1995-01-01</date>
+    <publisher/>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3836-1.jpg</cover>
+    <api_id>3836</api_id>
+  </Game>
+  <Game>
+    <name>Mario Is Missing!</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e51a3fcd</crc>
+    <date>1993-06-01</date>
+    <publisher>Software Toolworks</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2831-1.jpg</cover>
+    <api_id>2831</api_id>
+  </Game>
+  <Game>
+    <name>Mario Paint</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>38c9626c</crc>
+    <date>1992-05-05</date>
+    <publisher>Nintendo</publisher>
+    <region>Japan, USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1781-1.jpg</cover>
+    <api_id>1781</api_id>
+  </Game>
+  <Game>
+    <name>Mario's Early Years! - Fun with Letters</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>480b043a</crc>
+    <date>1994-10-01</date>
+    <publisher>Software Toolworks</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3837-1.jpg</cover>
+    <api_id>3837</api_id>
+  </Game>
+  <Game>
+    <name>Mario's Early Years! - Fun with Numbers</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8c0c37f4</crc>
+    <date>1994-10-01</date>
+    <publisher>The Software Toolworks</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3838-1.png</cover>
+    <api_id>3838</api_id>
+  </Game>
+  <Game>
+    <name>Mario's Early Years! - Preschool Fun</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>85a6b2a8</crc>
+    <date>1994-11-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3839-1.png</cover>
+    <api_id>3839</api_id>
+  </Game>
+  <Game>
+    <name>Mario's Time Machine</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>5e7397e0</crc>
+    <date>1993-12-01</date>
+    <publisher>Mindscape</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3840-2.jpg</cover>
+    <api_id>3840</api_id>
+  </Game>
+  <Game>
+    <name>Mark Davis' The Fishing Master</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>22a109b9</crc>
+    <date>1996-04-01</date>
+    <publisher>Natsume</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3841-1.jpg</cover>
+    <api_id>3841</api_id>
+  </Game>
+  <Game>
+    <name>Marko's Magic Football</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>4824a630</crc>
+    <date>1995-01-01</date>
+    <publisher>Cosmo</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3842-1.png</cover>
+    <api_id>3842</api_id>
+  </Game>
+  <Game>
+    <name>Marvel Super Heroes - War of the Gems</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>00af56e8</crc>
+    <date>1996-10-18</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3225-1.jpg</cover>
+    <api_id>3225</api_id>
+  </Game>
+  <Game>
+    <name>Mary Shelley's Frankenstein</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>91415d1e</crc>
+    <date>1994-11-01</date>
+    <publisher>Sony</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3843-1.jpg</cover>
+    <api_id>3843</api_id>
+  </Game>
+  <Game>
+    <name>Mask, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e17626e2</crc>
+    <date>1995-10-01</date>
+    <publisher>Black Pearl</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2068-1.jpg</cover>
+    <api_id>2068</api_id>
+  </Game>
+  <Game>
+    <name>Math Blaster - Episode 1</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>4c4e5f4a</crc>
+    <date>1994-10-01</date>
+    <publisher>Davidson &amp; Associates</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3844-1.jpg</cover>
+    <api_id>3844</api_id>
+  </Game>
+  <Game>
+    <name>Maui Mallard in Cold Shadow</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2d3b9662</crc>
+    <date>1996-11-01</date>
+    <publisher>Disney Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3845-2.jpg</cover>
+    <api_id>3845</api_id>
+  </Game>
+  <Game>
+    <name>Mecarobot Golf</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>82ceee3a</crc>
+    <date>1993-09-01</date>
+    <publisher>Toho</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3846-1.jpg</cover>
+    <api_id>3846</api_id>
+  </Game>
+  <Game>
+    <name>MechWarrior</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>40b7a858</crc>
+    <date>1993-05-01</date>
+    <publisher>Activision</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3572-1.jpg</cover>
+    <api_id>3572</api_id>
+  </Game>
+  <Game>
+    <name>MechWarrior 3050</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>c0acc92d</crc>
+    <date>1995-01-01</date>
+    <publisher>Tiburon Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3847-1.jpg</cover>
+    <api_id>3847</api_id>
+  </Game>
+  <Game>
+    <name>Mega lo Mania</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>e8042edf</crc>
+    <date>1994-01-01</date>
+    <publisher>Imagineer</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1782-1.jpg</cover>
+    <api_id>1782</api_id>
+  </Game>
+  <Game>
+    <name>Mega Man 7</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2d947536</crc>
+    <date>1995-03-24</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/292-2.jpg</cover>
+    <api_id>292</api_id>
+  </Game>
+  <Game>
+    <name>Mega Man Soccer</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>fa9ee2ce</crc>
+    <date>1994-04-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2494-1.jpg</cover>
+    <api_id>2494</api_id>
+  </Game>
+  <Game>
+    <name>Mega Man X</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ded53c64</crc>
+    <date>1994-01-21</date>
+    <publisher>Capcom</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/143-1.jpg</cover>
+    <api_id>143</api_id>
+  </Game>
+  <Game>
+    <name>Mega Man X2</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>947b0355</crc>
+    <date>1995-01-27</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1015-1.jpg</cover>
+    <api_id>1015</api_id>
+  </Game>
+  <Game>
+    <name>Mega Man X3</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>fa0fe671</crc>
+    <date>1996-01-26</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1016-1.jpg</cover>
+    <api_id>1016</api_id>
+  </Game>
+  <Game>
+    <name>Metal Combat - Falcon's Revenge</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>c3131b49</crc>
+    <date>1993-09-17</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2668-1.jpg</cover>
+    <api_id>2668</api_id>
+  </Game>
+  <Game>
+    <name>Metal Marines</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>66787df6</crc>
+    <date>1993-12-01</date>
+    <publisher>Namco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3848-1.jpg</cover>
+    <api_id>3848</api_id>
+  </Game>
+  <Game>
+    <name>Metal Morph</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>0adaa9da</crc>
+    <date>1994-12-01</date>
+    <publisher>FCI</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3573-1.jpg</cover>
+    <api_id>3573</api_id>
+  </Game>
+  <Game>
+    <name>Metal Warriors</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f2ab92d4</crc>
+    <date>1995-04-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3849-1.jpg</cover>
+    <api_id>3849</api_id>
+  </Game>
+  <Game>
+    <name>Michael Andretti's IndyCar Challenge</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>0fdb210e</crc>
+    <date>1994-09-01</date>
+    <publisher>Bullet Proof Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3850-1.jpg</cover>
+    <api_id>3850</api_id>
+  </Game>
+  <Game>
+    <name>Michael Jordan - Chaos in the Windy City</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f57dba3b</crc>
+    <date>1994-11-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5595-2.jpg</cover>
+    <api_id>5595</api_id>
+  </Game>
+  <Game>
+    <name>Mickey Mania - The Timeless Adventures of Mickey Mouse</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>08806b5b</crc>
+    <date>1994-10-01</date>
+    <publisher>Sony</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3114-2.jpg</cover>
+    <api_id>3114</api_id>
+  </Game>
+  <Game>
+    <name>Mickey's Playtown Adventure - A Day of Discovery!</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>53524952</crc>
+    <date>1994-01-01</date>
+    <publisher>Visual Concept</publisher>
+    <region>USA) (Proto</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5597-1.jpg</cover>
+    <api_id>5597</api_id>
+  </Game>
+  <Game>
+    <name>Mickey's Ultimate Challenge</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d6c60a84</crc>
+    <date>1994-01-01</date>
+    <publisher>Hi-Tech Expressions</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1785-1.jpg</cover>
+    <api_id>1785</api_id>
+  </Game>
+  <Game>
+    <name>Micro Machines</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>364e68bb</crc>
+    <date>1994-12-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2830-2.jpg</cover>
+    <api_id>2830</api_id>
+  </Game>
+  <Game>
+    <name>Micro Machines 2 - Turbo Tournament</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>1619b619</crc>
+    <date>1996-02-22</date>
+    <publisher>Ocean</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5598-1.jpg</cover>
+    <api_id>5598</api_id>
+  </Game>
+  <Game>
+    <name>Might and Magic II - Gates to Another World</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>4062244b</crc>
+    <date>1993-01-22</date>
+    <publisher>Elite</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5599-1.png</cover>
+    <api_id>5599</api_id>
+  </Game>
+  <Game>
+    <name>Might and Magic III - Isles of Terra</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8af25e7e</crc>
+    <date>1994-01-01</date>
+    <publisher>Iguana</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5611-1.jpg</cover>
+    <api_id>5611</api_id>
+  </Game>
+  <Game>
+    <name>Mighty Max</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>6fc3c105</crc>
+    <date>1995-02-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3574-1.jpg</cover>
+    <api_id>3574</api_id>
+  </Game>
+  <Game>
+    <name>Mighty Morphin Power Rangers</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a56eb77a</crc>
+    <date>1994-09-01</date>
+    <publisher>Bandai</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3226-1.jpg</cover>
+    <api_id>3226</api_id>
+  </Game>
+  <Game>
+    <name>Mighty Morphin Power Rangers - The Fighting Edition</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>460b0a60</crc>
+    <date>1995-09-15</date>
+    <publisher>Bandai</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5612-1.png</cover>
+    <api_id>5612</api_id>
+  </Game>
+  <Game>
+    <name>Mighty Morphin Power Rangers - The Movie</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e3ef6201</crc>
+    <date>1995-06-30</date>
+    <publisher>Bandai</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3131-1.jpg</cover>
+    <api_id>3131</api_id>
+  </Game>
+  <Game>
+    <name>MLBPA Baseball</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>62a92e57</crc>
+    <date>1994-03-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3227-1.jpg</cover>
+    <api_id>3227</api_id>
+  </Game>
+  <Game>
+    <name>Mohawk &amp; Headphone Jack</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>0b207e7f</crc>
+    <date>1995-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5613-1.jpg</cover>
+    <api_id>5613</api_id>
+  </Game>
+  <Game>
+    <name>Monopoly</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>88d54085</crc>
+    <date>1992-01-01</date>
+    <publisher>Parker Brothers</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5614-1.jpg</cover>
+    <api_id>5614</api_id>
+  </Game>
+  <Game>
+    <name>Mortal Kombat</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>def42945</crc>
+    <date>1993-09-13</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2826-1.jpg</cover>
+    <api_id>2826</api_id>
+  </Game>
+  <Game>
+    <name>Mortal Kombat 3</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>4e6af725</crc>
+    <date>1995-10-01</date>
+    <publisher>Williams</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2825-1.jpg</cover>
+    <api_id>2825</api_id>
+  </Game>
+  <Game>
+    <name>Mortal Kombat II</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>70bb5513</crc>
+    <date>1994-09-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2823-1.jpg</cover>
+    <api_id>2823</api_id>
+  </Game>
+  <Game>
+    <name>Mr. Do!</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1c1025e2</crc>
+    <date>1996-12-01</date>
+    <publisher>Imagineer</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/9247-1.jpg</cover>
+    <api_id>9247</api_id>
+  </Game>
+  <Game>
+    <name>Mr. Nutz</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>a99bdd9a</crc>
+    <date>1994-08-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5617-2.jpg</cover>
+    <api_id>5617</api_id>
+  </Game>
+  <Game>
+    <name>Ms. Pac-Man</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>74d210d3</crc>
+    <date>1996-01-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5619-2.jpg</cover>
+    <api_id>5619</api_id>
+  </Game>
+  <Game>
+    <name>Musya</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>011907a4</crc>
+    <date>1992-01-01</date>
+    <publisher>Seta</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5620-1.jpg</cover>
+    <api_id>5620</api_id>
+  </Game>
+  <Game>
+    <name>Natsume Championship Wrestling</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>d4dc20e1</crc>
+    <date>1994-06-10</date>
+    <publisher>Natsume</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5622-1.jpg</cover>
+    <api_id>5622</api_id>
+  </Game>
+  <Game>
+    <name>NBA All-Star Challenge</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a905a565</crc>
+    <date>1992-01-01</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5623-1.jpg</cover>
+    <api_id>5623</api_id>
+  </Game>
+  <Game>
+    <name>NBA Give 'n Go</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>68c8b643</crc>
+    <date>1995-11-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5624-1.jpg</cover>
+    <api_id>5624</api_id>
+  </Game>
+  <Game>
+    <name>NBA Hang Time</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>262ce76b</crc>
+    <date>1996-01-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5625-1.jpg</cover>
+    <api_id>5625</api_id>
+  </Game>
+  <Game>
+    <name>NBA Jam</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>8f42cae7</crc>
+    <date>1994-03-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2815-1.jpg</cover>
+    <api_id>2815</api_id>
+  </Game>
+  <Game>
+    <name>NBA Jam - Tournament Edition</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>1fbc1ddb</crc>
+    <date>1995-02-23</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2813-1.jpg</cover>
+    <api_id>2813</api_id>
+  </Game>
+  <Game>
+    <name>NBA Live 95</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>1cd2393d</crc>
+    <date>1994-12-03</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/293-1.jpg</cover>
+    <api_id>293</api_id>
+  </Game>
+  <Game>
+    <name>NBA Live 96</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>042a6495</crc>
+    <date>1995-01-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5626-1.jpg</cover>
+    <api_id>5626</api_id>
+  </Game>
+  <Game>
+    <name>NBA Live 97</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>5115b8e5</crc>
+    <date>1996-01-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5627-1.jpg</cover>
+    <api_id>5627</api_id>
+  </Game>
+  <Game>
+    <name>NBA Live 98</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>514bfcb5</crc>
+    <date>1997-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5628-1.jpg</cover>
+    <api_id>5628</api_id>
+  </Game>
+  <Game>
+    <name>NBA Showdown</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>65746f02</crc>
+    <date>1993-01-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5629-1.jpg</cover>
+    <api_id>5629</api_id>
+  </Game>
+  <Game>
+    <name>NCAA Basketball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>200370a2</crc>
+    <date>1992-01-01</date>
+    <publisher>HAL America</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5700-1.jpg</cover>
+    <api_id>5700</api_id>
+  </Game>
+  <Game>
+    <name>NCAA Final Four Basketball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>b07cfa91</crc>
+    <date>1994-01-01</date>
+    <publisher>Mindscape Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5701-1.jpg</cover>
+    <api_id>5701</api_id>
+  </Game>
+  <Game>
+    <name>NCAA Football</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2641c12a</crc>
+    <date>1994-01-01</date>
+    <publisher>Mindscape, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5702-1.jpg</cover>
+    <api_id>5702</api_id>
+  </Game>
+  <Game>
+    <name>New Horizons</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3c3c63e6</crc>
+    <date>1994-01-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6321-1.jpg</cover>
+    <api_id>6321</api_id>
+  </Game>
+  <Game>
+    <name>Newman-Haas IndyCar featuring Nigel Mansell</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a0f80c02</crc>
+    <date>1994-01-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5705-1.jpg</cover>
+    <api_id>5705</api_id>
+  </Game>
+  <Game>
+    <name>NFL Football</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>adb7731b</crc>
+    <date>1993-01-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5706-1.jpg</cover>
+    <api_id>5706</api_id>
+  </Game>
+  <Game>
+    <name>NFL Quarterback Club</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>79f16421</crc>
+    <date>1994-01-01</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5707-1.jpg</cover>
+    <api_id>5707</api_id>
+  </Game>
+  <Game>
+    <name>NFL Quarterback Club 96</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>e557689f</crc>
+    <date>1995-11-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/294-1.jpg</cover>
+    <api_id>294</api_id>
+  </Game>
+  <Game>
+    <name>NHL '94</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>42212a77</crc>
+    <date>1993-10-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3228-1.jpg</cover>
+    <api_id>3228</api_id>
+  </Game>
+  <Game>
+    <name>NHL '95</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2e9b1463</crc>
+    <date>1994-01-01</date>
+    <publisher>EA Sports</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5708-1.jpg</cover>
+    <api_id>5708</api_id>
+  </Game>
+  <Game>
+    <name>NHL '96</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>b6c6e7f3</crc>
+    <date>1996-01-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5709-1.jpg</cover>
+    <api_id>5709</api_id>
+  </Game>
+  <Game>
+    <name>NHL '97</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>06badb74</crc>
+    <date>1996-01-01</date>
+    <publisher>EA Sports</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5710-1.jpg</cover>
+    <api_id>5710</api_id>
+  </Game>
+  <Game>
+    <name>NHL '98</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>03cad2d2</crc>
+    <date>1997-01-01</date>
+    <publisher>EA Sports</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5711-1.jpg</cover>
+    <api_id>5711</api_id>
+  </Game>
+  <Game>
+    <name>NHL Stanley Cup</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>584ce502</crc>
+    <date>1993-11-02</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3229-1.jpg</cover>
+    <api_id>3229</api_id>
+  </Game>
+  <Game>
+    <name>NHLPA Hockey '93</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>c858eac4</crc>
+    <date>1993-01-01</date>
+    <publisher>EA Sports</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5712-1.jpg</cover>
+    <api_id>5712</api_id>
+  </Game>
+  <Game>
+    <name>Nickelodeon GUTS</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>233fec8c</crc>
+    <date>1994-01-01</date>
+    <publisher>Viacom New Media</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5713-1.jpg</cover>
+    <api_id>5713</api_id>
+  </Game>
+  <Game>
+    <name>Nigel Mansell's World Championship Racing</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>162252e2</crc>
+    <date>1993-07-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3230-1.jpg</cover>
+    <api_id>3230</api_id>
+  </Game>
+  <Game>
+    <name>Ninja Gaiden Trilogy</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>066fe797</crc>
+    <date>1995-08-10</date>
+    <publisher>Tecmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2094-1.jpg</cover>
+    <api_id>2094</api_id>
+  </Game>
+  <Game>
+    <name>Ninja Warriors, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7537d8d7</crc>
+    <date>1994-01-28</date>
+    <publisher>Taito</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3231-1.jpg</cover>
+    <api_id>3231</api_id>
+  </Game>
+  <Game>
+    <name>No Escape</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c1082880</crc>
+    <date>1994-11-11</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5714-1.png</cover>
+    <api_id>5714</api_id>
+  </Game>
+  <Game>
+    <name>Nobunaga's Ambition</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>49da3583</crc>
+    <date>1993-01-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5715-1.jpg</cover>
+    <api_id>5715</api_id>
+  </Game>
+  <Game>
+    <name>Nobunaga's Ambition - Lord of Darkness</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>4d7b39cd</crc>
+    <date>1994-10-01</date>
+    <publisher>KOEI</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3214-1.jpg</cover>
+    <api_id>3214</api_id>
+  </Game>
+  <Game>
+    <name>Nolan Ryan's Baseball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>1919baff</crc>
+    <date>1991-01-01</date>
+    <publisher>Romstar</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5716-1.jpg</cover>
+    <api_id>5716</api_id>
+  </Game>
+  <Game>
+    <name>Nosferatu</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>de762764</crc>
+    <date>1994-10-18</date>
+    <publisher>Seta</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5717-1.jpg</cover>
+    <api_id>5717</api_id>
+  </Game>
+  <Game>
+    <name>Obitus</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7c495b36</crc>
+    <date>1993-01-01</date>
+    <publisher>Bullet Proof Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5718-1.jpg</cover>
+    <api_id>5718</api_id>
+  </Game>
+  <Game>
+    <name>Ogre Battle - The March of the Black Queen</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>acfdb7b8</crc>
+    <date>1995-05-01</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3232-1.jpg</cover>
+    <api_id>3232</api_id>
+  </Game>
+  <Game>
+    <name>Olympic Summer Games</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6b882d11</crc>
+    <date>1996-01-01</date>
+    <publisher>U.S. Gold</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5719-1.jpg</cover>
+    <api_id>5719</api_id>
+  </Game>
+  <Game>
+    <name>On the Ball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>50ad3fe8</crc>
+    <date>1993-01-01</date>
+    <publisher>Taito</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5720-1.jpg</cover>
+    <api_id>5720</api_id>
+  </Game>
+  <Game>
+    <name>Operation Europe - Path to Victory 1939-45</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>f84c2bb6</crc>
+    <date>1994-01-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5721-1.jpg</cover>
+    <api_id>5721</api_id>
+  </Game>
+  <Game>
+    <name>Operation Logic Bomb</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>65bbe8b4</crc>
+    <date>1993-09-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3233-1.jpg</cover>
+    <api_id>3233</api_id>
+  </Game>
+  <Game>
+    <name>Operation Starfi5h</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>9d3e313f</crc>
+    <date>1993-01-01</date>
+    <publisher>Selling Points</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3801-1.jpg</cover>
+    <api_id>3801</api_id>
+  </Game>
+  <Game>
+    <name>Operation Thunderbolt</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3042b049</crc>
+    <date>1994-01-01</date>
+    <publisher>Taito Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5722-1.jpg</cover>
+    <api_id>5722</api_id>
+  </Game>
+  <Game>
+    <name>Oscar</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>cdf463c0</crc>
+    <date>1996-01-01</date>
+    <publisher>Titus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5723-1.jpg</cover>
+    <api_id>5723</api_id>
+  </Game>
+  <Game>
+    <name>Out of This World</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>5f40a869</crc>
+    <date>1992-11-01</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/33435-1.jpg</cover>
+    <api_id>33435</api_id>
+  </Game>
+  <Game>
+    <name>Out to Lunch</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3d0c8974</crc>
+    <date>1993-11-01</date>
+    <publisher>Mindscape</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5769-2.jpg</cover>
+    <api_id>5769</api_id>
+  </Game>
+  <Game>
+    <name>Outlander</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>a978b36f</crc>
+    <date>1993-04-01</date>
+    <publisher>Mindscape</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5770-1.png</cover>
+    <api_id>5770</api_id>
+  </Game>
+  <Game>
+    <name>P.T.O. - Pacific Theater of Operations</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>e51bbac8</crc>
+    <date>1993-09-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3239-1.jpg</cover>
+    <api_id>3239</api_id>
+  </Game>
+  <Game>
+    <name>P.T.O. II - Pacific Theater of Operations</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a614d268</crc>
+    <date>1995-01-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5771-1.jpg</cover>
+    <api_id>5771</api_id>
+  </Game>
+  <Game>
+    <name>Pac-Attack</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>191b1a19</crc>
+    <date>1993-01-01</date>
+    <publisher>Namco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5772-1.jpg</cover>
+    <api_id>5772</api_id>
+  </Game>
+  <Game>
+    <name>Pac-in-Time</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>44375368</crc>
+    <date>1994-12-01</date>
+    <publisher>Namco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5773-1.jpg</cover>
+    <api_id>5773</api_id>
+  </Game>
+  <Game>
+    <name>Pac-Man 2 - The New Adventures</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>9fc62bcc</crc>
+    <date>1994-09-01</date>
+    <publisher>Namco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3234-1.jpg</cover>
+    <api_id>3234</api_id>
+  </Game>
+  <Game>
+    <name>Packy &amp; Marlon</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>bab26e9c</crc>
+    <date>1994-01-01</date>
+    <publisher>Raya Systems</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5774-1.jpg</cover>
+    <api_id>5774</api_id>
+  </Game>
+  <Game>
+    <name>Pagemaster, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>26c38eee</crc>
+    <date>1994-01-01</date>
+    <publisher>Avalon</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6283-1.jpg</cover>
+    <api_id>6283</api_id>
+  </Game>
+  <Game>
+    <name>Paladin's Quest</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>37fe8126</crc>
+    <date>1993-10-01</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2249-1.jpg</cover>
+    <api_id>2249</api_id>
+  </Game>
+  <Game>
+    <name>Paperboy 2</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>c85aa66a</crc>
+    <date>1991-11-01</date>
+    <publisher>Mindscape</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2916-1.jpg</cover>
+    <api_id>2916</api_id>
+  </Game>
+  <Game>
+    <name>Parodius</name>
+    <players/>
+    <simultaneous/>
+    <crc>6ffa308c</crc>
+    <date>1992</date>
+    <publisher>Konami</publisher>
+    <region>Europe</region>
+    <cover/>
+  </Game>
+  <Game>
+    <name>Peace Keepers, The</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>8071e5db</crc>
+    <date>1994-01-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2591-1.jpg</cover>
+    <api_id>2591</api_id>
+  </Game>
+  <Game>
+    <name>PGA European Tour</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>914f2ea3</crc>
+    <date>1996-01-01</date>
+    <publisher>Black Pearl</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5775-1.jpg</cover>
+    <api_id>5775</api_id>
+  </Game>
+  <Game>
+    <name>PGA Tour 96</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>bc5df071</crc>
+    <date>1995-01-01</date>
+    <publisher>Black Pearl Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5776-1.jpg</cover>
+    <api_id>5776</api_id>
+  </Game>
+  <Game>
+    <name>PGA Tour Golf</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>b6566944</crc>
+    <date>1991-01-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5777-1.jpg</cover>
+    <api_id>5777</api_id>
+  </Game>
+  <Game>
+    <name>Phalanx - The Enforce Fighter A-144</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>dc90a8ab</crc>
+    <date>1992-10-01</date>
+    <publisher>Kotobuki</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3235-1.jpg</cover>
+    <api_id>3235</api_id>
+  </Game>
+  <Game>
+    <name>Phantom 2040</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>35e8fb28</crc>
+    <date>1995-09-01</date>
+    <publisher>Viacom New Media</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5779-1.jpg</cover>
+    <api_id>5779</api_id>
+  </Game>
+  <Game>
+    <name>Pieces</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>bb6c3c54</crc>
+    <date>1994-12-01</date>
+    <publisher>Atlus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2223-2.jpg</cover>
+    <api_id>2223</api_id>
+  </Game>
+  <Game>
+    <name>Pilotwings</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>266c44ed</crc>
+    <date>1991-08-23</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2418-1.jpg</cover>
+    <api_id>2418</api_id>
+  </Game>
+  <Game>
+    <name>Pinball Dreams</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>81107ce2</crc>
+    <date>1994-04-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2069-1.jpg</cover>
+    <api_id>2069</api_id>
+  </Game>
+  <Game>
+    <name>Pinball Fantasies</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>822ad378</crc>
+    <date>1995-02-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5780-1.jpg</cover>
+    <api_id>5780</api_id>
+  </Game>
+  <Game>
+    <name>Pink Goes to Hollywood</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8bae9438</crc>
+    <date>1993-11-01</date>
+    <publisher>TecMagik</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5781-1.jpg</cover>
+    <api_id>5781</api_id>
+  </Game>
+  <Game>
+    <name>Pinocchio</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>00fad8fd</crc>
+    <date>1995-01-01</date>
+    <publisher>Disney Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5782-1.jpg</cover>
+    <api_id>5782</api_id>
+  </Game>
+  <Game>
+    <name>Pirates of Dark Water, The</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>7ca0ca4d</crc>
+    <date>1994-01-01</date>
+    <publisher>Mitsui</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6284-1.jpg</cover>
+    <api_id>6284</api_id>
+  </Game>
+  <Game>
+    <name>Pit-Fighter</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>9fab69fc</crc>
+    <date>1992-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5783-1.jpg</cover>
+    <api_id>5783</api_id>
+  </Game>
+  <Game>
+    <name>Pitfall - The Mayan Adventure</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>03e67d38</crc>
+    <date>1994-11-01</date>
+    <publisher>Activision</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2918-1.jpg</cover>
+    <api_id>2918</api_id>
+  </Game>
+  <Game>
+    <name>Plok!</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>bbd678f6</crc>
+    <date>1993-09-01</date>
+    <publisher>Tradewest</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5784-1.jpg</cover>
+    <api_id>5784</api_id>
+  </Game>
+  <Game>
+    <name>Pocky &amp; Rocky</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2b0e7ea3</crc>
+    <date>1993-06-01</date>
+    <publisher>Natsume</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5785-1.jpg</cover>
+    <api_id>5785</api_id>
+  </Game>
+  <Game>
+    <name>Pocky &amp; Rocky 2</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>fc00bb1b</crc>
+    <date>1994-11-01</date>
+    <publisher>Natsume</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/11002-1.png</cover>
+    <api_id>11002</api_id>
+  </Game>
+  <Game>
+    <name>Pop'n TwinBee</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>588a9707</crc>
+    <date>1993-01-01</date>
+    <publisher>Konami</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2199-1.jpg</cover>
+    <api_id>2199</api_id>
+  </Game>
+  <Game>
+    <name>Pop'n TwinBee - Rainbow Bell Adventures</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>91a03035</crc>
+    <date>1993-01-01</date>
+    <publisher>Konami</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5786-1.jpg</cover>
+    <api_id>5786</api_id>
+  </Game>
+  <Game>
+    <name>Populous</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2df4aa0f</crc>
+    <date>1991-09-30</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3236-1.jpg</cover>
+    <api_id>3236</api_id>
+  </Game>
+  <Game>
+    <name>Populous II - Trials of the Olympian Gods</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>6c28cc39</crc>
+    <date>1993-01-22</date>
+    <publisher>Imagineer</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5787-1.jpg</cover>
+    <api_id>5787</api_id>
+  </Game>
+  <Game>
+    <name>Porky Pig's Haunted Holiday</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f09e91a1</crc>
+    <date>1995-01-01</date>
+    <publisher>Sunsoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5788-1.png</cover>
+    <api_id>5788</api_id>
+  </Game>
+  <Game>
+    <name>Power Drive</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>0bfdca70</crc>
+    <date>1994-01-01</date>
+    <publisher>Selling Points</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5789-1.jpg</cover>
+    <api_id>5789</api_id>
+  </Game>
+  <Game>
+    <name>Power Instinct</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>cb8a4f8e</crc>
+    <date>1994-01-01</date>
+    <publisher>Atlus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5790-1.jpg</cover>
+    <api_id>5790</api_id>
+  </Game>
+  <Game>
+    <name>Power Moves</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>c2e094b5</crc>
+    <date>1993-01-22</date>
+    <publisher>Kaneko</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3237-1.jpg</cover>
+    <api_id>3237</api_id>
+  </Game>
+  <Game>
+    <name>Power Piggs of the Dark Age</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e945530d</crc>
+    <date>1996-05-01</date>
+    <publisher>Titus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5791-1.png</cover>
+    <api_id>5791</api_id>
+  </Game>
+  <Game>
+    <name>Power Rangers Zeo - Battle Racers</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>389300cf</crc>
+    <date>1996-09-17</date>
+    <publisher>Bandai</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5821-1.jpg</cover>
+    <api_id>5821</api_id>
+  </Game>
+  <Game>
+    <name>PowerMonger</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>bc06f982</crc>
+    <date>1993-01-01</date>
+    <publisher>Imagineer</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5792-1.jpg</cover>
+    <api_id>5792</api_id>
+  </Game>
+  <Game>
+    <name>Prehistorik Man</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>cb4f87bb</crc>
+    <date>1995-01-01</date>
+    <publisher>Titus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5793-1.jpg</cover>
+    <api_id>5793</api_id>
+  </Game>
+  <Game>
+    <name>Primal Rage</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>3753e4b6</crc>
+    <date>1995-08-01</date>
+    <publisher>Time Warner Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5794-1.jpg</cover>
+    <api_id>5794</api_id>
+  </Game>
+  <Game>
+    <name>Prince of Persia</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>891bb2bb</crc>
+    <date>1992-11-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3238-1.jpg</cover>
+    <api_id>3238</api_id>
+  </Game>
+  <Game>
+    <name>Prince of Persia 2 - The Shadow &amp; The Flame</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>50581d9d</crc>
+    <date>1996-10-01</date>
+    <publisher>Titus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2198-1.jpg</cover>
+    <api_id>2198</api_id>
+  </Game>
+  <Game>
+    <name>Pro Quarterback</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6910626d</crc>
+    <date>1992-05-06</date>
+    <publisher>Tradewest</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1729-1.jpg</cover>
+    <api_id>1729</api_id>
+  </Game>
+  <Game>
+    <name>Pro Sport Hockey</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a9cc0a74</crc>
+    <date>1993-01-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5795-1.jpg</cover>
+    <api_id>5795</api_id>
+  </Game>
+  <Game>
+    <name>Push-Over</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>fa06d5f5</crc>
+    <date>1992-12-31</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5796-1.jpg</cover>
+    <api_id>5796</api_id>
+  </Game>
+  <Game>
+    <name>Putty Squad</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>c061f0a8</crc>
+    <date>1994-01-01</date>
+    <publisher>Ocean Software</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2664-1.jpg</cover>
+    <api_id>2664</api_id>
+  </Game>
+  <Game>
+    <name>Q-bert 3</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>694cbfe4</crc>
+    <date>1992-10-01</date>
+    <publisher>NTVIC</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5800-1.jpg</cover>
+    <api_id>5800</api_id>
+  </Game>
+  <Game>
+    <name>R-Type III - The Third Lightning</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>642b656b</crc>
+    <date>1994-10-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2927-2.jpg</cover>
+    <api_id>2927</api_id>
+  </Game>
+  <Game>
+    <name>R.P.M. Racing</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>f7933734</crc>
+    <date>1991-01-01</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5818-1.jpg</cover>
+    <api_id>5818</api_id>
+  </Game>
+  <Game>
+    <name>Race Drivin'</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c5bab870</crc>
+    <date>1992-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5801-1.jpg</cover>
+    <api_id>5801</api_id>
+  </Game>
+  <Game>
+    <name>Radical Rex</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e2b8da18</crc>
+    <date>1994-01-01</date>
+    <publisher>Allan</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5802-1.jpg</cover>
+    <api_id>5802</api_id>
+  </Game>
+  <Game>
+    <name>Raiden Trad</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>02ce6c96</crc>
+    <date>1992-04-01</date>
+    <publisher>Electro Brain</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3240-1.jpg</cover>
+    <api_id>3240</api_id>
+  </Game>
+  <Game>
+    <name>Rampart</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>aed8892a</crc>
+    <date>1991-01-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5804-1.jpg</cover>
+    <api_id>5804</api_id>
+  </Game>
+  <Game>
+    <name>Ranma 1-2 - Hard Battle</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>8e4dadcd</crc>
+    <date>1992-12-25</date>
+    <publisher>Masaya</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2665-1.jpg</cover>
+    <api_id>2665</api_id>
+  </Game>
+  <Game>
+    <name>Rap Jam - Volume One</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>adf4ffce</crc>
+    <date>1994-01-01</date>
+    <publisher>Mandingo Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5805-1.jpg</cover>
+    <api_id>5805</api_id>
+  </Game>
+  <Game>
+    <name>Realm</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0744ba5b</crc>
+    <date>1996-01-01</date>
+    <publisher>PMR</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5806-1.png</cover>
+    <api_id>5806</api_id>
+  </Game>
+  <Game>
+    <name>Redline F-1 Racer</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e5faadd2</crc>
+    <date>1993-08-01</date>
+    <publisher>Absolute Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2544-1.jpg</cover>
+    <api_id>2544</api_id>
+  </Game>
+  <Game>
+    <name>Relief Pitcher</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2f48ff14</crc>
+    <date>1993-01-01</date>
+    <publisher>Left Field Productions</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5807-1.jpg</cover>
+    <api_id>5807</api_id>
+  </Game>
+  <Game>
+    <name>Ren &amp; Stimpy Show, The - Buckeroos!</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>672ebf39</crc>
+    <date>1992-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6285-1.jpg</cover>
+    <api_id>6285</api_id>
+  </Game>
+  <Game>
+    <name>Ren &amp; Stimpy Show, The - Fire Dogs</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0b472197</crc>
+    <date>1994-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6286-1.jpg</cover>
+    <api_id>6286</api_id>
+  </Game>
+  <Game>
+    <name>Ren &amp; Stimpy Show, The - Time Warp</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>de8fe3e8</crc>
+    <date>1994-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6287-1.jpg</cover>
+    <api_id>6287</api_id>
+  </Game>
+  <Game>
+    <name>Ren &amp; Stimpy Show, The - Veediots!</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>fd1c12a3</crc>
+    <date>1994-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6288-1.jpg</cover>
+    <api_id>6288</api_id>
+  </Game>
+  <Game>
+    <name>Revolution X</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>0dc5e7ba</crc>
+    <date>1995-12-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2938-1.jpg</cover>
+    <api_id>2938</api_id>
+  </Game>
+  <Game>
+    <name>Rex Ronan - Experimental Surgeon</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>105ac679</crc>
+    <date>1994-05-06</date>
+    <publisher>Raya Systems</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3241-1.jpg</cover>
+    <api_id>3241</api_id>
+  </Game>
+  <Game>
+    <name>Riddick Bowe Boxing</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a967a041</crc>
+    <date>1993-01-01</date>
+    <publisher>Extreme Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5809-1.jpg</cover>
+    <api_id>5809</api_id>
+  </Game>
+  <Game>
+    <name>Rise of the Phoenix</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>908b90b1</crc>
+    <date>1995-02-01</date>
+    <publisher>KOEI</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3242-1.jpg</cover>
+    <api_id>3242</api_id>
+  </Game>
+  <Game>
+    <name>Rise of the Robots</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>83ba0ac0</crc>
+    <date>1994-12-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2669-1.jpg</cover>
+    <api_id>2669</api_id>
+  </Game>
+  <Game>
+    <name>Rival Turf!</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>ca988f59</crc>
+    <date>1992-03-06</date>
+    <publisher>Jaleco USA</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5810-1.png</cover>
+    <api_id>5810</api_id>
+  </Game>
+  <Game>
+    <name>Road Riot 4WD</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>20367643</crc>
+    <date>1992-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5811-1.jpg</cover>
+    <api_id>5811</api_id>
+  </Game>
+  <Game>
+    <name>Road Runner's Death Valley Rally</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>5980d75d</crc>
+    <date>1992-11-01</date>
+    <publisher>Suncorp</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3243-1.jpg</cover>
+    <api_id>3243</api_id>
+  </Game>
+  <Game>
+    <name>RoboCop 3</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>3502f9b3</crc>
+    <date>1992-09-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2943-2.jpg</cover>
+    <api_id>2943</api_id>
+  </Game>
+  <Game>
+    <name>RoboCop versus The Terminator</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>f5ab5d91</crc>
+    <date>1993-10-07</date>
+    <publisher>Virgin Games</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2614-1.jpg</cover>
+    <api_id>2614</api_id>
+  </Game>
+  <Game>
+    <name>Robotrek</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7ad4aadc</crc>
+    <date>1994-10-01</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3244-1.jpg</cover>
+    <api_id>3244</api_id>
+  </Game>
+  <Game>
+    <name>Rock n' Roll Racing</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>7d06f473</crc>
+    <date>1993-06-04</date>
+    <publisher>Interplay Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2246-1.jpg</cover>
+    <api_id>2246</api_id>
+  </Game>
+  <Game>
+    <name>Rocketeer, The</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>4c68a3c7</crc>
+    <date>1992-01-01</date>
+    <publisher>IGS</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6289-1.jpg</cover>
+    <api_id>6289</api_id>
+  </Game>
+  <Game>
+    <name>Rocko's Modern Life - Spunky's Dangerous Day</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>197b4cba</crc>
+    <date>1994-04-01</date>
+    <publisher>Viacom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5485-1.jpg</cover>
+    <api_id>5485</api_id>
+  </Game>
+  <Game>
+    <name>Rocky Rodent</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>c81a7b07</crc>
+    <date>1993-09-01</date>
+    <publisher>Irem</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3245-1.jpg</cover>
+    <api_id>3245</api_id>
+  </Game>
+  <Game>
+    <name>Roger Clemens' MVP Baseball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a012d1ad</crc>
+    <date>1992-01-01</date>
+    <publisher>LJN</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5814-1.jpg</cover>
+    <api_id>5814</api_id>
+  </Game>
+  <Game>
+    <name>Romance of the Three Kingdoms II</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>8033574a</crc>
+    <date>1992-01-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5815-1.jpg</cover>
+    <api_id>5815</api_id>
+  </Game>
+  <Game>
+    <name>Romance of the Three Kingdoms III - Dragon of Destiny</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>523b0d02</crc>
+    <date>1993-01-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5816-1.jpg</cover>
+    <api_id>5816</api_id>
+  </Game>
+  <Game>
+    <name>Romance of the Three Kingdoms IV - Wall of Fire</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>82af5b69</crc>
+    <date>1995-07-01</date>
+    <publisher>KOEI</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3246-1.jpg</cover>
+    <api_id>3246</api_id>
+  </Game>
+  <Game>
+    <name>Run Saber</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>8708e5bb</crc>
+    <date>1993-06-08</date>
+    <publisher>Atlus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5486-1.jpg</cover>
+    <api_id>5486</api_id>
+  </Game>
+  <Game>
+    <name>Sailormoon</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>CD89020D</crc>
+    <date>1994-07-08</date>
+    <publisher>Bandai</publisher>
+    <region>France</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/48077-1.jpg</cover>
+    <api_id>48077</api_id>
+  </Game>
+  <Game>
+    <name>Samurai Shodown</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2e614a53</crc>
+    <date>1994-11-01</date>
+    <publisher>Takara</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5823-1.jpg</cover>
+    <api_id>5823</api_id>
+  </Game>
+  <Game>
+    <name>Saturday Night Slam Masters</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>54161830</crc>
+    <date>1994-01-01</date>
+    <publisher>Avalon</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3247-1.jpg</cover>
+    <api_id>3247</api_id>
+  </Game>
+  <Game>
+    <name>Scooby-Doo Mystery</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>98d7611e</crc>
+    <date>1995-01-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/297-1.jpg</cover>
+    <api_id>297</api_id>
+  </Game>
+  <Game>
+    <name>SeaQuest DSV</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>a6579e03</crc>
+    <date>1994-01-01</date>
+    <publisher>Cosmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5825-1.jpg</cover>
+    <api_id>5825</api_id>
+  </Game>
+  <Game>
+    <name>Secret of Evermore</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>a5c0045e</crc>
+    <date>1995-10-01</date>
+    <publisher>Squaresoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1311-1.jpg</cover>
+    <api_id>1311</api_id>
+  </Game>
+  <Game>
+    <name>Secret of Mana</name>
+    <players>3</players>
+    <simultaneous>1</simultaneous>
+    <crc>d0176b24</crc>
+    <date>1993-08-06</date>
+    <publisher>Squaresoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1253-1.jpg</cover>
+    <api_id>1253</api_id>
+  </Game>
+  <Game>
+    <name>Shadow, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>13380511</crc>
+    <date>2002-07-18</date>
+    <publisher>Ocean</publisher>
+    <region>USA) (Proto</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5830-1.jpg</cover>
+    <api_id>5830</api_id>
+  </Game>
+  <Game>
+    <name>Shadowrun</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3f34dff0</crc>
+    <date>1993-05-01</date>
+    <publisher>Data East</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2945-1.jpg</cover>
+    <api_id>2945</api_id>
+  </Game>
+  <Game>
+    <name>Shanghai II - Dragon's Eye</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2fec70b6</crc>
+    <date>1992-01-01</date>
+    <publisher>Yeno</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5835-1.jpg</cover>
+    <api_id>5835</api_id>
+  </Game>
+  <Game>
+    <name>Shaq Fu</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>52916c9d</crc>
+    <date>1994-10-01</date>
+    <publisher>Electronic Arts</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3258-1.jpg</cover>
+    <api_id>3258</api_id>
+  </Game>
+  <Game>
+    <name>Shien's Revenge</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>5bb2e6c3</crc>
+    <date>1994-01-01</date>
+    <publisher>Vic Tokai</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5838-1.jpg</cover>
+    <api_id>5838</api_id>
+  </Game>
+  <Game>
+    <name>Side Pocket</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>597c2bfe</crc>
+    <date>1993-01-01</date>
+    <publisher>Iguana</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5847-1.jpg</cover>
+    <api_id>5847</api_id>
+  </Game>
+  <Game>
+    <name>SimAnt</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d08c05df</crc>
+    <date>1993-01-01</date>
+    <publisher>Maxis</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/37758-1.jpg</cover>
+    <api_id>37758</api_id>
+  </Game>
+  <Game>
+    <name>SimCity</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8aedd3a1</crc>
+    <date>1991-08-13</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3259-1.jpg</cover>
+    <api_id>3259</api_id>
+  </Game>
+  <Game>
+    <name>SimCity 2000</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2d5dc011</crc>
+    <date>1996-11-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5849-1.jpg</cover>
+    <api_id>5849</api_id>
+  </Game>
+  <Game>
+    <name>SimEarth - The Living Planet</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7fa5b218</crc>
+    <date>1993-01-01</date>
+    <publisher>FCI</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5852-1.jpg</cover>
+    <api_id>5852</api_id>
+  </Game>
+  <Game>
+    <name>Simpsons, The - Bart's Nightmare</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ed1c03c2</crc>
+    <date>1992-01-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2764-1.jpg</cover>
+    <api_id>2764</api_id>
+  </Game>
+  <Game>
+    <name>Sink or Swim</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>dd329f85</crc>
+    <date>1994-01-01</date>
+    <publisher>Mindscape Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5856-1.png</cover>
+    <api_id>5856</api_id>
+  </Game>
+  <Game>
+    <name>Skuljagger - Revolt of the Westicans</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>e58a6d01</crc>
+    <date>1992-10-01</date>
+    <publisher>American Softworks</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/298-1.jpg</cover>
+    <api_id>298</api_id>
+  </Game>
+  <Game>
+    <name>Skyblazer</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f13b00b0</crc>
+    <date>1994-01-01</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3260-1.jpg</cover>
+    <api_id>3260</api_id>
+  </Game>
+  <Game>
+    <name>Smart Ball</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3cfe77ab</crc>
+    <date>1991-01-01</date>
+    <publisher>Sony Imagesoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5862-1.png</cover>
+    <api_id>5862</api_id>
+  </Game>
+  <Game>
+    <name>Smash Tennis</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>6f7d1745</crc>
+    <date>1994-01-01</date>
+    <publisher>Virgin Interactive</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5957-1.jpg</cover>
+    <api_id>5957</api_id>
+  </Game>
+  <Game>
+    <name>Smurfs Travel the World, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>22947169</crc>
+    <date>1996-10-01</date>
+    <publisher>Infogrames</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/36130-1.png</cover>
+    <api_id>36130</api_id>
+  </Game>
+  <Game>
+    <name>Smurfs, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2ae148d6</crc>
+    <date>1994-01-01</date>
+    <publisher>Infogrames</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6290-2.jpg</cover>
+    <api_id>6290</api_id>
+  </Game>
+  <Game>
+    <name>Snow White in Happily Ever After</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d68d1ab3</crc>
+    <date>1994-01-01</date>
+    <publisher>American Softworks Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3261-1.jpg</cover>
+    <api_id>3261</api_id>
+  </Game>
+  <Game>
+    <name>Soldiers of Fortune</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>cf719a93</crc>
+    <date>1993-01-01</date>
+    <publisher>Laguna</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5959-1.jpg</cover>
+    <api_id>5959</api_id>
+  </Game>
+  <Game>
+    <name>Sonic Blast Man</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8886396e</crc>
+    <date>1992-01-01</date>
+    <publisher>Taito Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2580-1.jpg</cover>
+    <api_id>2580</api_id>
+  </Game>
+  <Game>
+    <name>Sonic Blast Man II</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>24229a34</crc>
+    <date>1994-01-01</date>
+    <publisher>Taito Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5960-1.png</cover>
+    <api_id>5960</api_id>
+  </Game>
+  <Game>
+    <name>SOS</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>09ae53f5</crc>
+    <date>1994-06-01</date>
+    <publisher>Vic Tokai</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5961-1.jpg</cover>
+    <api_id>5961</api_id>
+  </Game>
+  <Game>
+    <name>Soul Blazer</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>31b965db</crc>
+    <date>1992-11-27</date>
+    <publisher>Enix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3262-1.jpg</cover>
+    <api_id>3262</api_id>
+  </Game>
+  <Game>
+    <name>Space Ace</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f4bb0888</crc>
+    <date>1993-01-01</date>
+    <publisher>Imagineer</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5962-1.png</cover>
+    <api_id>5962</api_id>
+  </Game>
+  <Game>
+    <name>Space Football - One on One</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>55dcf09e</crc>
+    <date>1992-01-01</date>
+    <publisher>Triffix</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5963-1.jpg</cover>
+    <api_id>5963</api_id>
+  </Game>
+  <Game>
+    <name>Space Invaders - The Original Game</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>caf035f5</crc>
+    <date>1997-11-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3263-1.jpg</cover>
+    <api_id>3263</api_id>
+  </Game>
+  <Game>
+    <name>Space Megaforce</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>11202781</crc>
+    <date>1992-01-01</date>
+    <publisher>Toho</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3264-1.jpg</cover>
+    <api_id>3264</api_id>
+  </Game>
+  <Game>
+    <name>Spanky's Quest</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ca68c5c3</crc>
+    <date>1991-01-01</date>
+    <publisher>Natsume</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5964-1.png</cover>
+    <api_id>5964</api_id>
+  </Game>
+  <Game>
+    <name>Sparkster</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>40d11c94</crc>
+    <date>1994-10-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2671-1.jpg</cover>
+    <api_id>2671</api_id>
+  </Game>
+  <Game>
+    <name>Spawn</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>4e1dafd0</crc>
+    <date>1995-10-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3284-1.png</cover>
+    <api_id>3284</api_id>
+  </Game>
+  <Game>
+    <name>Spectre</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>ade6e0d8</crc>
+    <date>1994-05-01</date>
+    <publisher>Cybersoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3265-1.jpg</cover>
+    <api_id>3265</api_id>
+  </Game>
+  <Game>
+    <name>Speed Racer in My Most Dangerous Adventures</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>aa44287c</crc>
+    <date>1994-01-01</date>
+    <publisher>Accolade</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5965-1.jpg</cover>
+    <api_id>5965</api_id>
+  </Game>
+  <Game>
+    <name>Speedy Gonzales - Los Gatos Bandidos</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>cb0653d0</crc>
+    <date>1994-01-01</date>
+    <publisher>Mitsui</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6127-1.png</cover>
+    <api_id>6127</api_id>
+  </Game>
+  <Game>
+    <name>Spider-Man</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c99e174e</crc>
+    <date>1994-01-01</date>
+    <publisher>Cosmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2954-1.png</cover>
+    <api_id>2954</api_id>
+  </Game>
+  <Game>
+    <name>Spider-Man-Venom - Maximum Carnage</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7ef2bb0c</crc>
+    <date>1994-09-04</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3266-1.jpg</cover>
+    <api_id>3266</api_id>
+  </Game>
+  <Game>
+    <name>Spider-Man-X-Men - Arcade's Revenge</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ae878ccb</crc>
+    <date>1992-11-01</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5871-1.png</cover>
+    <api_id>5871</api_id>
+  </Game>
+  <Game>
+    <name>Spindizzy Worlds</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>52b68163</crc>
+    <date>1992-01-01</date>
+    <publisher>Electric Dreams</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6129-1.png</cover>
+    <api_id>6129</api_id>
+  </Game>
+  <Game>
+    <name>Spirou</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>797e2e82</crc>
+    <date>1995-01-01</date>
+    <publisher>Konami</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6130-1.jpg</cover>
+    <api_id>6130</api_id>
+  </Game>
+  <Game>
+    <name>Sporting News Power Baseball, The</name>
+    <players/>
+    <simultaneous/>
+    <crc>315af696</crc>
+    <date>1995</date>
+    <publisher>Hudson</publisher>
+    <region>USA</region>
+    <cover/>
+  </Game>
+  <Game>
+    <name>Sports Illustrated Championship Football &amp; Baseball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>d4874966</crc>
+    <date>1993-01-01</date>
+    <publisher>Malibu Games</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6131-1.jpg</cover>
+    <api_id>6131</api_id>
+  </Game>
+  <Game>
+    <name>Star Fox</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8fc4e6d0</crc>
+    <date>1993-02-21</date>
+    <publisher>Nintendo</publisher>
+    <region>USA) (Rev 2</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1730-1.jpg</cover>
+    <api_id>1730</api_id>
+  </Game>
+  <Game>
+    <name>Star Fox</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>cd1f04b8</crc>
+    <date>1993-02-21</date>
+    <publisher>Nintendo</publisher>
+    <region>USA) (Rev 2</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1730-1.jpg</cover>
+    <api_id>1730</api_id>
+  </Game>
+  <Game>
+    <name>Star Trek - Deep Space Nine - Crossroads of Time</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>9a245fa3</crc>
+    <date>1995-01-01</date>
+    <publisher>Avalon</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6133-1.jpg</cover>
+    <api_id>6133</api_id>
+  </Game>
+  <Game>
+    <name>Star Trek - Starfleet Academy - Starship Bridge Simulator</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>2db38d24</crc>
+    <date>1994-12-01</date>
+    <publisher>Interplay</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3267-1.jpg</cover>
+    <api_id>3267</api_id>
+  </Game>
+  <Game>
+    <name>Star Trek - The Next Generation - Future's Past</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>8de80428</crc>
+    <date>1994-03-01</date>
+    <publisher>Spectrum Holobyte</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3268-1.jpg</cover>
+    <api_id>3268</api_id>
+  </Game>
+  <Game>
+    <name>Stargate</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>526ce576</crc>
+    <date>1994-01-01</date>
+    <publisher>Cosmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6136-1.jpg</cover>
+    <api_id>6136</api_id>
+  </Game>
+  <Game>
+    <name>Steel Talons</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>4ea9f93f</crc>
+    <date>1993-01-01</date>
+    <publisher>Left Field Productions</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6137-1.jpg</cover>
+    <api_id>6137</api_id>
+  </Game>
+  <Game>
+    <name>Sterling Sharpe - End 2 End</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>70d9c906</crc>
+    <date>1995-01-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6138-1.jpg</cover>
+    <api_id>6138</api_id>
+  </Game>
+  <Game>
+    <name>Stone Protectors</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a7e58592</crc>
+    <date>1994-01-01</date>
+    <publisher>Kemco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6139-1.jpg</cover>
+    <api_id>6139</api_id>
+  </Game>
+  <Game>
+    <name>Street Combat</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>1969bbd9</crc>
+    <date>1993-04-09</date>
+    <publisher>Irem</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6140-1.jpg</cover>
+    <api_id>6140</api_id>
+  </Game>
+  <Game>
+    <name>Street Fighter Alpha 2</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>9c59ddff</crc>
+    <date>1996-12-20</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3269-1.jpg</cover>
+    <api_id>3269</api_id>
+  </Game>
+  <Game>
+    <name>Street Fighter II</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>bc3dcd9d</crc>
+    <date>1992-06-10</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3122-1.jpg</cover>
+    <api_id>3122</api_id>
+  </Game>
+  <Game>
+    <name>Street Fighter II Turbo</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>a45cadd6</crc>
+    <date>1993-07-10</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2538-1.jpg</cover>
+    <api_id>2538</api_id>
+  </Game>
+  <Game>
+    <name>Street Hockey '95</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>97357a1b</crc>
+    <date>1994-01-01</date>
+    <publisher>GTE Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6141-1.jpg</cover>
+    <api_id>6141</api_id>
+  </Game>
+  <Game>
+    <name>Street Racer</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>63e8b7d5</crc>
+    <date>1994-12-01</date>
+    <publisher>Ubisoft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6142-2.jpg</cover>
+    <api_id>6142</api_id>
+  </Game>
+  <Game>
+    <name>Strike Gunner S.T.G</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>d054e288</crc>
+    <date>1995-01-01</date>
+    <publisher>Tecmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2456-1.jpg</cover>
+    <api_id>2456</api_id>
+  </Game>
+  <Game>
+    <name>Stunt Race FX</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>380c2635</crc>
+    <date>1994-07-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3270-1.jpg</cover>
+    <api_id>3270</api_id>
+  </Game>
+  <Game>
+    <name>Sunset Riders</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>52ada404</crc>
+    <date>1993-10-05</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3271-1.jpg</cover>
+    <api_id>3271</api_id>
+  </Game>
+  <Game>
+    <name>Super Adventure Island</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>dcd46848</crc>
+    <date>1992-04-01</date>
+    <publisher>Hudson</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2082-1.jpg</cover>
+    <api_id>2082</api_id>
+  </Game>
+  <Game>
+    <name>Super Adventure Island II</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>52fe16fd</crc>
+    <date>1994-10-01</date>
+    <publisher>Hudson</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2083-1.jpg</cover>
+    <api_id>2083</api_id>
+  </Game>
+  <Game>
+    <name>Super Alfred Chicken</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>f21c5a9d</crc>
+    <date>1994-02-01</date>
+    <publisher>Mindscape</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3754-1.jpg</cover>
+    <api_id>3754</api_id>
+  </Game>
+  <Game>
+    <name>Super Aquatic Games Starring the Aquabats, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>2a5ddac0</crc>
+    <date>1993-10-01</date>
+    <publisher>Seika Corp.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/9248-1.jpg</cover>
+    <api_id>9248</api_id>
+  </Game>
+  <Game>
+    <name>Super Baseball Simulator 1.000</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>aa760fec</crc>
+    <date>1991-12-01</date>
+    <publisher>Culture Brain</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3272-1.jpg</cover>
+    <api_id>3272</api_id>
+  </Game>
+  <Game>
+    <name>Super Bases Loaded</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6b971f1e</crc>
+    <date>1991-09-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/9249-1.jpg</cover>
+    <api_id>9249</api_id>
+  </Game>
+  <Game>
+    <name>Super Bases Loaded 3 - License to Steal</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>f0540d1b</crc>
+    <date>1994-01-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6146-1.jpg</cover>
+    <api_id>6146</api_id>
+  </Game>
+  <Game>
+    <name>Super Bases Loaded II</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e14128ca</crc>
+    <date>1994-01-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6145-1.jpg</cover>
+    <api_id>6145</api_id>
+  </Game>
+  <Game>
+    <name>Super Batter Up</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>5896c854</crc>
+    <date>1992-01-01</date>
+    <publisher>Namco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6147-1.jpg</cover>
+    <api_id>6147</api_id>
+  </Game>
+  <Game>
+    <name>Super Battleship</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>6fcea1a1</crc>
+    <date>1993-01-01</date>
+    <publisher>Mindscape Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3273-1.jpg</cover>
+    <api_id>3273</api_id>
+  </Game>
+  <Game>
+    <name>Super Battletank - War in the Gulf</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>77811b34</crc>
+    <date>1992-01-01</date>
+    <publisher>Absolute Entertainment, Inc.</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6148-1.jpg</cover>
+    <api_id>6148</api_id>
+  </Game>
+  <Game>
+    <name>Super Battletank 2</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>70a292d6</crc>
+    <date>1993-01-01</date>
+    <publisher>Absolute Entertainment, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6149-1.jpg</cover>
+    <api_id>6149</api_id>
+  </Game>
+  <Game>
+    <name>Super Black Bass</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>57d9fd61</crc>
+    <date>1993-05-01</date>
+    <publisher>Hot-B</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2084-1.jpg</cover>
+    <api_id>2084</api_id>
+  </Game>
+  <Game>
+    <name>Super Bomberman</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>63a8e2c6</crc>
+    <date>1993-09-01</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/277-1.jpg</cover>
+    <api_id>277</api_id>
+  </Game>
+  <Game>
+    <name>Super Bomberman 2</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>9c1f11e4</crc>
+    <date>1994-12-12</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2534-1.jpg</cover>
+    <api_id>2534</api_id>
+  </Game>
+  <Game>
+    <name>Super Bomberman 3</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>a096a6e5</crc>
+    <date>1995-01-01</date>
+    <publisher>Hudson Soft</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2661-1.jpg</cover>
+    <api_id>2661</api_id>
+  </Game>
+  <Game>
+    <name>Super Bonk</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>5688b581</crc>
+    <date>1994-11-01</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/9250-1.jpg</cover>
+    <api_id>9250</api_id>
+  </Game>
+  <Game>
+    <name>Super Bowling</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>94945b50</crc>
+    <date>1992-01-01</date>
+    <publisher>Technos</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6151-1.jpg</cover>
+    <api_id>6151</api_id>
+  </Game>
+  <Game>
+    <name>Super Buster Bros.</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>9526d1aa</crc>
+    <date>1992-01-01</date>
+    <publisher>Avalon</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6152-1.png</cover>
+    <api_id>6152</api_id>
+  </Game>
+  <Game>
+    <name>Super Caesars Palace</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>a2381221</crc>
+    <date>1993-01-01</date>
+    <publisher>Virgin Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6153-1.jpg</cover>
+    <api_id>6153</api_id>
+  </Game>
+  <Game>
+    <name>Super Castlevania IV</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>b64ffb12</crc>
+    <date>1991-12-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1308-1.jpg</cover>
+    <api_id>1308</api_id>
+  </Game>
+  <Game>
+    <name>Super Chase H.Q.</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>6ef3b9c7</crc>
+    <date>1993-01-01</date>
+    <publisher>Taito Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6154-1.jpg</cover>
+    <api_id>6154</api_id>
+  </Game>
+  <Game>
+    <name>Super Conflict - The Mideast</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>f254d5cf</crc>
+    <date>1993-01-01</date>
+    <publisher>Vertigo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6155-1.jpg</cover>
+    <api_id>6155</api_id>
+  </Game>
+  <Game>
+    <name>Super Copa</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>49e53877</crc>
+    <date>2015-11-01</date>
+    <publisher>Playtronic</publisher>
+    <region>Brazil) (Es,Pt</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/32483-1.jpg</cover>
+    <api_id>32483</api_id>
+  </Game>
+  <Game>
+    <name>Super Dany</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0F578F67</crc>
+    <date>1995-01-01</date>
+    <publisher>Virgin Games</publisher>
+    <region>France</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/36397-1.jpg</cover>
+    <api_id>36397</api_id>
+  </Game>
+  <Game>
+    <name>Super Double Dragon</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>09ed12a5</crc>
+    <date>1992-10-01</date>
+    <publisher>Tradewest</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2085-1.jpg</cover>
+    <api_id>2085</api_id>
+  </Game>
+  <Game>
+    <name>Super Ghouls'n Ghosts</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>6aaba901</crc>
+    <date>1991-11-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2224-1.jpg</cover>
+    <api_id>2224</api_id>
+  </Game>
+  <Game>
+    <name>Super Goal! 2</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>c5829306</crc>
+    <date>1993-01-01</date>
+    <publisher>Jaleco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6159-1.jpg</cover>
+    <api_id>6159</api_id>
+  </Game>
+  <Game>
+    <name>Super Godzilla</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>6a187c70</crc>
+    <date>1993-01-01</date>
+    <publisher>Toho</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6161-1.jpg</cover>
+    <api_id>6161</api_id>
+  </Game>
+  <Game>
+    <name>Super High Impact</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2eed70fb</crc>
+    <date>1993-01-01</date>
+    <publisher>Acclaim Entertainment, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6162-1.png</cover>
+    <api_id>6162</api_id>
+  </Game>
+  <Game>
+    <name>Super Ice Hockey</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>fb1d16c4</crc>
+    <date>1994-03-25</date>
+    <publisher>Sunsoft</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/36348-1.jpg</cover>
+    <api_id>36348</api_id>
+  </Game>
+  <Game>
+    <name>Super International Cricket</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>89cd72b0</crc>
+    <date>1994-01-01</date>
+    <publisher>Nintendo</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6166-1.jpg</cover>
+    <api_id>6166</api_id>
+  </Game>
+  <Game>
+    <name>Super James Pond</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d7c34122</crc>
+    <date>1993-07-23</date>
+    <publisher>American Softworks Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3274-1.jpg</cover>
+    <api_id>3274</api_id>
+  </Game>
+  <Game>
+    <name>Super Mario All-Stars</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>925637c7</crc>
+    <date>1993-08-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2093-1.jpg</cover>
+    <api_id>2093</api_id>
+  </Game>
+  <Game>
+    <name>Super Mario All-Stars + Super Mario World</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>f84305b1</crc>
+    <date>1993-12-16</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3275-1.jpg</cover>
+    <api_id>3275</api_id>
+  </Game>
+  <Game>
+    <name>Super Mario Kart</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>cd80db86</crc>
+    <date>1992-09-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/41-1.jpg</cover>
+    <api_id>41</api_id>
+  </Game>
+  <Game>
+    <name>Super Mario RPG - Legend of the Seven Stars</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1b8a0625</crc>
+    <date>1996-05-13</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/232-1.jpg</cover>
+    <api_id>232</api_id>
+  </Game>
+  <Game>
+    <name>Super Mario World</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>b19ed489</crc>
+    <date>1991-08-13</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/136-1.jpg</cover>
+    <api_id>136</api_id>
+  </Game>
+  <Game>
+    <name>Super Mario World 2 - Yoshi's Island</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>cf98ddaa</crc>
+    <date>1995-10-04</date>
+    <publisher>Nintendo</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/137-1.jpg</cover>
+    <api_id>137</api_id>
+  </Game>
+  <Game>
+    <name>Super Metroid</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d63ed5f8</crc>
+    <date>1994-04-18</date>
+    <publisher>Nintendo</publisher>
+    <region>Japan, USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/299-1.jpg</cover>
+    <api_id>299</api_id>
+  </Game>
+  <Game>
+    <name>Super Morph</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>388f6daa</crc>
+    <date>1993-01-01</date>
+    <publisher>Sony</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2204-1.jpg</cover>
+    <api_id>2204</api_id>
+  </Game>
+  <Game>
+    <name>Super Ninja Boy</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>6bcbba10</crc>
+    <date>1993-04-01</date>
+    <publisher>Culture Brain Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2672-1.jpg</cover>
+    <api_id>2672</api_id>
+  </Game>
+  <Game>
+    <name>Super Noah's Ark 3D</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>A2315A14</crc>
+    <date>1994-11-25</date>
+    <publisher>Wisdom Tree</publisher>
+    <region>USA) (Unl</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6225-1.jpg</cover>
+    <api_id>6225</api_id>
+  </Game>
+  <Game>
+    <name>Super Nova</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>460def25</crc>
+    <date>1993-12-01</date>
+    <publisher>Taito</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6226-1.jpg</cover>
+    <api_id>6226</api_id>
+  </Game>
+  <Game>
+    <name>Super Off Road</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>fe263383</crc>
+    <date>1991-12-01</date>
+    <publisher>Tradewest</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2796-1.jpg</cover>
+    <api_id>2796</api_id>
+  </Game>
+  <Game>
+    <name>Super Off Road - The Baja</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>cb483ead</crc>
+    <date>1993-09-01</date>
+    <publisher>Tradewest</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3276-1.jpg</cover>
+    <api_id>3276</api_id>
+  </Game>
+  <Game>
+    <name>Super Pinball - Behind the Mask</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>008463a0</crc>
+    <date>1994-01-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6167-1.jpg</cover>
+    <api_id>6167</api_id>
+  </Game>
+  <Game>
+    <name>Super Play Action Football</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>0f359a60</crc>
+    <date>1992-01-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6168-1.jpg</cover>
+    <api_id>6168</api_id>
+  </Game>
+  <Game>
+    <name>Super Punch-Out!!</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e2f92f84</crc>
+    <date>1994-10-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1307-1.jpg</cover>
+    <api_id>1307</api_id>
+  </Game>
+  <Game>
+    <name>Super Putty</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>746087c1</crc>
+    <date>1993-01-01</date>
+    <publisher>U.S. Gold</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5797-1.jpg</cover>
+    <api_id>5797</api_id>
+  </Game>
+  <Game>
+    <name>Super R-Type</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8b22c830</crc>
+    <date>1991-09-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3277-1.jpg</cover>
+    <api_id>3277</api_id>
+  </Game>
+  <Game>
+    <name>Super R.B.I. Baseball</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>31db6cfe</crc>
+    <date>1995-01-01</date>
+    <publisher>Time Warner Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6169-1.jpg</cover>
+    <api_id>6169</api_id>
+  </Game>
+  <Game>
+    <name>Super Scope 6</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>b141ea99</crc>
+    <date>1992-02-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/47919-1.jpg</cover>
+    <api_id>47919</api_id>
+  </Game>
+  <Game>
+    <name>Super Slam Dunk</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>3effc9e5</crc>
+    <date>1993-01-01</date>
+    <publisher>Virgin Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6171-1.jpg</cover>
+    <api_id>6171</api_id>
+  </Game>
+  <Game>
+    <name>Super Slap Shot</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>7355c9b9</crc>
+    <date>1993-08-20</date>
+    <publisher>Virgin</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/48350-1.jpg</cover>
+    <api_id>48350</api_id>
+  </Game>
+  <Game>
+    <name>Super Smash T.V.</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2d0b20d0</crc>
+    <date>1992-02-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/5863-1.jpg</cover>
+    <api_id>5863</api_id>
+  </Game>
+  <Game>
+    <name>Super Soccer</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>4fd164d8</crc>
+    <date>1992-05-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6173-1.png</cover>
+    <api_id>6173</api_id>
+  </Game>
+  <Game>
+    <name>Super Soccer Champ</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>b31d35a5</crc>
+    <date>1992-06-01</date>
+    <publisher>Taito Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/13918-1.jpg</cover>
+    <api_id>13918</api_id>
+  </Game>
+  <Game>
+    <name>Super Solitaire</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c8e80d55</crc>
+    <date>1993-01-01</date>
+    <publisher>Extreme Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6174-1.jpg</cover>
+    <api_id>6174</api_id>
+  </Game>
+  <Game>
+    <name>Super Star Wars</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>be47f6c6</crc>
+    <date>1992-11-01</date>
+    <publisher>JVC</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2658-1.jpg</cover>
+    <api_id>2658</api_id>
+  </Game>
+  <Game>
+    <name>Super Star Wars - Return of the Jedi</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>4a5f30d8</crc>
+    <date>1994-10-01</date>
+    <publisher>JVC</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2660-1.jpg</cover>
+    <api_id>2660</api_id>
+  </Game>
+  <Game>
+    <name>Super Star Wars - The Empire Strikes Back</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1e7ea62c</crc>
+    <date>1993-10-01</date>
+    <publisher>JVC</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2659-1.jpg</cover>
+    <api_id>2659</api_id>
+  </Game>
+  <Game>
+    <name>Super Street Fighter II</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>f16d5ce9</crc>
+    <date>1994-06-01</date>
+    <publisher>CAPCOM</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2792-1.jpg</cover>
+    <api_id>2792</api_id>
+  </Game>
+  <Game>
+    <name>Super Strike Eagle</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ecf79841</crc>
+    <date>1993-01-01</date>
+    <publisher>Microprose</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6175-1.jpg</cover>
+    <api_id>6175</api_id>
+  </Game>
+  <Game>
+    <name>Super Tennis</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>8d383776</crc>
+    <date>1991-11-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3278-1.jpg</cover>
+    <api_id>3278</api_id>
+  </Game>
+  <Game>
+    <name>Super Troll Islands</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f9690be9</crc>
+    <date>1993-01-01</date>
+    <publisher>American Softworks Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6176-1.png</cover>
+    <api_id>6176</api_id>
+  </Game>
+  <Game>
+    <name>Super Turrican</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3a7e8215</crc>
+    <date>1993-05-01</date>
+    <publisher>Seika Corp</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6177-1.jpg</cover>
+    <api_id>6177</api_id>
+  </Game>
+  <Game>
+    <name>Super Turrican 2</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d2ffabac</crc>
+    <date>1995-11-01</date>
+    <publisher>Ocean</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6178-1.png</cover>
+    <api_id>6178</api_id>
+  </Game>
+  <Game>
+    <name>Super Valis IV</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>29e8ac9f</crc>
+    <date>1992-01-01</date>
+    <publisher>Atlus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6327-1.jpg</cover>
+    <api_id>6327</api_id>
+  </Game>
+  <Game>
+    <name>Super Widget</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7dd199ec</crc>
+    <date>1993-01-01</date>
+    <publisher>Atlus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3914-1.jpg</cover>
+    <api_id>3914</api_id>
+  </Game>
+  <Game>
+    <name>Suzuka 8 Hours</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>54740b9b</crc>
+    <date>1993-01-01</date>
+    <publisher>Namco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6227-1.jpg</cover>
+    <api_id>6227</api_id>
+  </Game>
+  <Game>
+    <name>SWAT Kats - The Radical Squadron</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ea2a23fb</crc>
+    <date>1995-08-18</date>
+    <publisher>Hudson Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6228-1.jpg</cover>
+    <api_id>6228</api_id>
+  </Game>
+  <Game>
+    <name>Syndicate</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d74570d3</crc>
+    <date>1994-01-01</date>
+    <publisher>Laguna</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6229-1.jpg</cover>
+    <api_id>6229</api_id>
+  </Game>
+  <Game>
+    <name>Syvalion</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f1884ecb</crc>
+    <date>1992-01-01</date>
+    <publisher>Taito Corporation</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6230-1.jpg</cover>
+    <api_id>6230</api_id>
+  </Game>
+  <Game>
+    <name>T2 - The Arcade Game</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>5dc6b9fe</crc>
+    <date>1993-01-01</date>
+    <publisher>Acclaim Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6231-1.jpg</cover>
+    <api_id>6231</api_id>
+  </Game>
+  <Game>
+    <name>Taz-Mania</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>b17230ae</crc>
+    <date>1993-05-01</date>
+    <publisher>Sunsoft</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6233-1.jpg</cover>
+    <api_id>6233</api_id>
+  </Game>
+  <Game>
+    <name>Tecmo Secret of the Stars</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ef968ed1</crc>
+    <date>1995-07-01</date>
+    <publisher>Tecmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2670-1.jpg</cover>
+    <api_id>2670</api_id>
+  </Game>
+  <Game>
+    <name>Tecmo Super Baseball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e302d853</crc>
+    <date>1994-01-01</date>
+    <publisher>Tecmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6248-1.jpg</cover>
+    <api_id>6248</api_id>
+  </Game>
+  <Game>
+    <name>Tecmo Super Bowl</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>cde3746b</crc>
+    <date>1993-01-01</date>
+    <publisher>Tecmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6250-1.jpg</cover>
+    <api_id>6250</api_id>
+  </Game>
+  <Game>
+    <name>Tecmo Super Bowl II - Special Edition</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>d67d507b</crc>
+    <date>1994-01-01</date>
+    <publisher>Tecmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6251-1.jpg</cover>
+    <api_id>6251</api_id>
+  </Game>
+  <Game>
+    <name>Tecmo Super Bowl III - Final Edition</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>8ef1411f</crc>
+    <date>1995-01-01</date>
+    <publisher>Tecmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6252-1.jpg</cover>
+    <api_id>6252</api_id>
+  </Game>
+  <Game>
+    <name>Tecmo Super NBA Basketball</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>1b6f0b43</crc>
+    <date>1993-01-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6253-1.jpg</cover>
+    <api_id>6253</api_id>
+  </Game>
+  <Game>
+    <name>Teenage Mutant Ninja Turtles - Tournament Fighters</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e2fe5dbf</crc>
+    <date>1993-09-04</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3283-1.jpg</cover>
+    <api_id>3283</api_id>
+  </Game>
+  <Game>
+    <name>Teenage Mutant Ninja Turtles IV - Turtles in Time</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>5940bd99</crc>
+    <date>1992-08-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/188-1.png</cover>
+    <api_id>188</api_id>
+  </Game>
+  <Game>
+    <name>Terminator 2 - Judgment Day</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f729b19e</crc>
+    <date>1993-01-01</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6256-1.jpg</cover>
+    <api_id>6256</api_id>
+  </Game>
+  <Game>
+    <name>Terminator, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d71e6c3b</crc>
+    <date>1993-01-01</date>
+    <publisher>Mindscape Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6292-1.jpg</cover>
+    <api_id>6292</api_id>
+  </Game>
+  <Game>
+    <name>Terranigma</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>974523ff</crc>
+    <date>1996-12-19</date>
+    <publisher>Enix</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1783-2.jpg</cover>
+    <api_id>1783</api_id>
+  </Game>
+  <Game>
+    <name>Tetris &amp; Dr. Mario</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6c852ef3</crc>
+    <date>1994-12-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3280-1.jpg</cover>
+    <api_id>3280</api_id>
+  </Game>
+  <Game>
+    <name>Tetris 2</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>3bc7054a</crc>
+    <date>1994-08-08</date>
+    <publisher>Nintendo</publisher>
+    <region>USA) (Rev 1</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6258-1.jpg</cover>
+    <api_id>6258</api_id>
+  </Game>
+  <Game>
+    <name>Tetris Attack</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6c128210</crc>
+    <date>1996-11-03</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3281-1.jpg</cover>
+    <api_id>3281</api_id>
+  </Game>
+  <Game>
+    <name>Theme Park</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ca0e041c</crc>
+    <date>1996-11-11</date>
+    <publisher>Ocean</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6296-1.jpg</cover>
+    <api_id>6296</api_id>
+  </Game>
+  <Game>
+    <name>Thomas the Tank Engine and Friends</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>bb4cd5a4</crc>
+    <date>1993-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6297-1.jpg</cover>
+    <api_id>6297</api_id>
+  </Game>
+  <Game>
+    <name>Thunder Spirits</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>522fe837</crc>
+    <date>1991-01-01</date>
+    <publisher>Seika</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6298-1.jpg</cover>
+    <api_id>6298</api_id>
+  </Game>
+  <Game>
+    <name>Tick, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>12ab22a7</crc>
+    <date>1994-01-01</date>
+    <publisher>Fox Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6293-1.png</cover>
+    <api_id>6293</api_id>
+  </Game>
+  <Game>
+    <name>Time Slip</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>838d0304</crc>
+    <date>1993-01-01</date>
+    <publisher>Sales Curve</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6299-1.jpg</cover>
+    <api_id>6299</api_id>
+  </Game>
+  <Game>
+    <name>Time Trax</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>f6628157</crc>
+    <date>1994-01-01</date>
+    <publisher>Cosmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6300-1.jpg</cover>
+    <api_id>6300</api_id>
+  </Game>
+  <Game>
+    <name>Timecop</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>130b0933</crc>
+    <date>1995-04-06</date>
+    <publisher>JVC</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6301-1.png</cover>
+    <api_id>6301</api_id>
+  </Game>
+  <Game>
+    <name>Timon &amp; Pumbaa's Jungle Games</name>
+    <players>1</players>
+    <simultaneous/>
+    <crc>341c6fb0</crc>
+    <date>1997-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2205-1.jpg</cover>
+    <api_id>2205</api_id>
+  </Game>
+  <Game>
+    <name>Tin Star</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ec26f75b</crc>
+    <date>1994-11-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/9251-1.jpg</cover>
+    <api_id>9251</api_id>
+  </Game>
+  <Game>
+    <name>Tintin - Prisoners of the Sun</name>
+    <players/>
+    <simultaneous/>
+    <crc>a94a47be</crc>
+    <date>1997</date>
+    <publisher>Infogrames</publisher>
+    <region>Europe</region>
+    <cover/>
+  </Game>
+  <Game>
+    <name>Tintin in Tibet</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>f1dce2b7</crc>
+    <date>1995-12-15</date>
+    <publisher>Infogrames</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/22474-1.jpg</cover>
+    <api_id>22474</api_id>
+  </Game>
+  <Game>
+    <name>Tiny Toon Adventures - Buster Busts Loose!</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ab48d27a</crc>
+    <date>1993-02-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3282-1.jpg</cover>
+    <api_id>3282</api_id>
+  </Game>
+  <Game>
+    <name>Tiny Toon Adventures - Wacky Sports Challenge</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>afe72ff0</crc>
+    <date>1994-12-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6302-1.jpg</cover>
+    <api_id>6302</api_id>
+  </Game>
+  <Game>
+    <name>TKO Super Championship Boxing</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>fd4af462</crc>
+    <date>1993-01-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6303-1.jpg</cover>
+    <api_id>6303</api_id>
+  </Game>
+  <Game>
+    <name>TNN Bass Tournament of Champions</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c367b683</crc>
+    <date>1993-01-01</date>
+    <publisher>American Softworks Corporation</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6304-1.jpg</cover>
+    <api_id>6304</api_id>
+  </Game>
+  <Game>
+    <name>Tom &amp; Jerry</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8b1dafbb</crc>
+    <date>1993-04-01</date>
+    <publisher>Hi Tech Expressions</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6305-1.jpg</cover>
+    <api_id>6305</api_id>
+  </Game>
+  <Game>
+    <name>Tommy Moe's Winter Extreme - Skiing and Snowboarding</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3d005f22</crc>
+    <date>1994-06-01</date>
+    <publisher>Electro Brain</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/9253-1.jpg</cover>
+    <api_id>9253</api_id>
+  </Game>
+  <Game>
+    <name>Tony Meola's Sidekicks Soccer</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>32b658c1</crc>
+    <date>1993-11-01</date>
+    <publisher>Electro Brain</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/9252-1.jpg</cover>
+    <api_id>9252</api_id>
+  </Game>
+  <Game>
+    <name>Top Gear</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>d34c49b7</crc>
+    <date>1992-01-01</date>
+    <publisher>Kemco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2208-1.jpg</cover>
+    <api_id>2208</api_id>
+  </Game>
+  <Game>
+    <name>Top Gear 2</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2b88bee8</crc>
+    <date>1993-01-01</date>
+    <publisher>Kemco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2209-1.png</cover>
+    <api_id>2209</api_id>
+  </Game>
+  <Game>
+    <name>Top Gear 3000</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>a20be998</crc>
+    <date>1994-01-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2210-1.jpg</cover>
+    <api_id>2210</api_id>
+  </Game>
+  <Game>
+    <name>Total Carnage</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e27ff2bc</crc>
+    <date>1993-01-01</date>
+    <publisher>Malibu Games</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6307-1.jpg</cover>
+    <api_id>6307</api_id>
+  </Game>
+  <Game>
+    <name>Toy Story</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8328822b</crc>
+    <date>1995-12-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3553-1.png</cover>
+    <api_id>3553</api_id>
+  </Game>
+  <Game>
+    <name>Toys</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>efebf501</crc>
+    <date>1993-01-01</date>
+    <publisher>Absolute Entertainment, Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6308-1.jpg</cover>
+    <api_id>6308</api_id>
+  </Game>
+  <Game>
+    <name>Troddlers</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>6a7ff02d</crc>
+    <date>1993-01-01</date>
+    <publisher>Sales Curve</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6310-1.jpg</cover>
+    <api_id>6310</api_id>
+  </Game>
+  <Game>
+    <name>Troy Aikman NFL Football</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>0b26446b</crc>
+    <date>1994-01-01</date>
+    <publisher>Sony</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6311-1.jpg</cover>
+    <api_id>6311</api_id>
+  </Game>
+  <Game>
+    <name>True Golf Classics - Pebble Beach Golf Links</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>18c5ad58</crc>
+    <date>1993-01-01</date>
+    <publisher>T&amp;E Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6312-1.jpg</cover>
+    <api_id>6312</api_id>
+  </Game>
+  <Game>
+    <name>True Golf Classics - Waialae Country Club</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e9d6c61e</crc>
+    <date>1991-01-01</date>
+    <publisher>T&amp;E Soft</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6313-1.jpg</cover>
+    <api_id>6313</api_id>
+  </Game>
+  <Game>
+    <name>True Golf Classics - Wicked 18</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>26177842</crc>
+    <date>1993-01-01</date>
+    <publisher>Bullet Proof Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6345-1.jpg</cover>
+    <api_id>6345</api_id>
+  </Game>
+  <Game>
+    <name>True Lies</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>40ca49ae</crc>
+    <date>1994-01-01</date>
+    <publisher>LJN Ltd.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2656-1.jpg</cover>
+    <api_id>2656</api_id>
+  </Game>
+  <Game>
+    <name>Tuff E Nuff</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>865f37bf</crc>
+    <date>1993-03-26</date>
+    <publisher>Jaleco Entertainment</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2211-1.jpg</cover>
+    <api_id>2211</api_id>
+  </Game>
+  <Game>
+    <name>Turbo Toons</name>
+    <players>4+</players>
+    <simultaneous/>
+    <crc>26a9c3f4</crc>
+    <date>1994-01-01</date>
+    <publisher>Allan</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1766-1.jpg</cover>
+    <api_id>1766</api_id>
+  </Game>
+  <Game>
+    <name>Turn and Burn - No-Fly Zone</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>87bfa0b8</crc>
+    <date>1993-01-01</date>
+    <publisher>Sony</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6314-1.jpg</cover>
+    <api_id>6314</api_id>
+  </Game>
+  <Game>
+    <name>Twisted Tales of Spike McFang, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>8c2068d1</crc>
+    <date>1994-01-01</date>
+    <publisher>Bullet Proof Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2673-1.jpg</cover>
+    <api_id>2673</api_id>
+  </Game>
+  <Game>
+    <name>U.N. Squadron</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>231f0f67</crc>
+    <date>1992-01-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3287-1.jpg</cover>
+    <api_id>3287</api_id>
+  </Game>
+  <Game>
+    <name>Ultima - Runes of Virtue II</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>cc4eebf4</crc>
+    <date>1994-01-01</date>
+    <publisher>FCI</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6317-1.jpg</cover>
+    <api_id>6317</api_id>
+  </Game>
+  <Game>
+    <name>Ultima VI - The False Prophet</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>9277c9f7</crc>
+    <date>1993-01-01</date>
+    <publisher>FCI</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6315-1.jpg</cover>
+    <api_id>6315</api_id>
+  </Game>
+  <Game>
+    <name>Ultima VII - The Black Gate</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>e790f52f</crc>
+    <date>1994-01-01</date>
+    <publisher>FCI</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6316-1.jpg</cover>
+    <api_id>6316</api_id>
+  </Game>
+  <Game>
+    <name>Ultimate Fighter</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>9dfc8897</crc>
+    <date>1994-06-16</date>
+    <publisher>Culture Brain</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6318-1.jpg</cover>
+    <api_id>6318</api_id>
+  </Game>
+  <Game>
+    <name>Ultimate Mortal Kombat 3</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>f5bfe41e</crc>
+    <date>1996-10-01</date>
+    <publisher>Williams</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3285-1.jpg</cover>
+    <api_id>3285</api_id>
+  </Game>
+  <Game>
+    <name>Ultraman - Towards the Future</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1ded2814</crc>
+    <date>1991-10-01</date>
+    <publisher>Bandai</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3286-1.jpg</cover>
+    <api_id>3286</api_id>
+  </Game>
+  <Game>
+    <name>Uncharted Waters</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>95724a2f</crc>
+    <date>1991-01-01</date>
+    <publisher>Koei</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6320-1.jpg</cover>
+    <api_id>6320</api_id>
+  </Game>
+  <Game>
+    <name>Uniracers</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>383858c7</crc>
+    <date>1994-12-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2212-1.jpg</cover>
+    <api_id>2212</api_id>
+  </Game>
+  <Game>
+    <name>Universal Soldier</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>59180F1C</crc>
+    <date>1994-01-01</date>
+    <publisher>Accolade</publisher>
+    <region>USA) (Proto</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6322-1.jpg</cover>
+    <api_id>6322</api_id>
+  </Game>
+  <Game>
+    <name>Untouchables, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>c70f2374</crc>
+    <date>1993-01-01</date>
+    <publisher>Ocean Software</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6294-1.png</cover>
+    <api_id>6294</api_id>
+  </Game>
+  <Game>
+    <name>Urban Strike</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>b9bf7990</crc>
+    <date>1995-11-01</date>
+    <publisher>Black Pearl</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6324-2.jpg</cover>
+    <api_id>6324</api_id>
+  </Game>
+  <Game>
+    <name>Utopia - The Creation of a Nation</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>252a96c7</crc>
+    <date>1993-01-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6325-1.jpg</cover>
+    <api_id>6325</api_id>
+  </Game>
+  <Game>
+    <name>Vegas Stakes</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>03a0e935</crc>
+    <date>1993-01-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6328-1.jpg</cover>
+    <api_id>6328</api_id>
+  </Game>
+  <Game>
+    <name>Venom-Spider-Man - Separation Anxiety</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>919c509d</crc>
+    <date>1995-11-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/7624-1.png</cover>
+    <api_id>7624</api_id>
+  </Game>
+  <Game>
+    <name>Virtual Bart</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>5d0addda</crc>
+    <date>1994-09-01</date>
+    <publisher>Acclaim</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6330-1.png</cover>
+    <api_id>6330</api_id>
+  </Game>
+  <Game>
+    <name>Virtual Soccer</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>ecb8a53a</crc>
+    <date>1993-01-01</date>
+    <publisher>Avalon</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2213-1.jpg</cover>
+    <api_id>2213</api_id>
+  </Game>
+  <Game>
+    <name>Vortex</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>31b1ad00</crc>
+    <date>1994-09-01</date>
+    <publisher>Electro Brain</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2655-1.jpg</cover>
+    <api_id>2655</api_id>
+  </Game>
+  <Game>
+    <name>War 2410</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ad2dc53a</crc>
+    <date>1995-01-01</date>
+    <publisher>Advanced Productions</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6331-1.jpg</cover>
+    <api_id>6331</api_id>
+  </Game>
+  <Game>
+    <name>War 3010 - The Revolution</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>98c974be</crc>
+    <date>1996-01-01</date>
+    <publisher>Advanced Productions</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6332-1.jpg</cover>
+    <api_id>6332</api_id>
+  </Game>
+  <Game>
+    <name>Wario's Woods</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2d1004f1</crc>
+    <date>1994-01-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6333-1.png</cover>
+    <api_id>6333</api_id>
+  </Game>
+  <Game>
+    <name>Warlock</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>a47884d0</crc>
+    <date>1994-01-01</date>
+    <publisher>Cosmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6334-1.jpg</cover>
+    <api_id>6334</api_id>
+  </Game>
+  <Game>
+    <name>WarpSpeed</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1e10a1d1</crc>
+    <date>1992-01-01</date>
+    <publisher>Accolade</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6335-1.jpg</cover>
+    <api_id>6335</api_id>
+  </Game>
+  <Game>
+    <name>Waterworld</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7acf2ac6</crc>
+    <date>1995-01-01</date>
+    <publisher>Ocean</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2214-1.png</cover>
+    <api_id>2214</api_id>
+  </Game>
+  <Game>
+    <name>Wayne Gretzky and the NHLPA All-Stars</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>0b7d22b2</crc>
+    <date>1995-01-01</date>
+    <publisher>Time Warner Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6336-1.jpg</cover>
+    <api_id>6336</api_id>
+  </Game>
+  <Game>
+    <name>Wayne's World</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0d426a15</crc>
+    <date>1993-01-01</date>
+    <publisher>THQ</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6337-1.jpg</cover>
+    <api_id>6337</api_id>
+  </Game>
+  <Game>
+    <name>WCW Super Brawl Wrestling</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>8b477300</crc>
+    <date>1994-11-25</date>
+    <publisher>FCI</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6338-1.jpg</cover>
+    <api_id>6338</api_id>
+  </Game>
+  <Game>
+    <name>We're Back! - A Dinosaur's Story</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>3f654414</crc>
+    <date>1993-01-01</date>
+    <publisher>Hi Tech Expressions</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6342-1.png</cover>
+    <api_id>6342</api_id>
+  </Game>
+  <Game>
+    <name>WeaponLord</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>0e7e7102</crc>
+    <date>1995-09-01</date>
+    <publisher>Namco</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6339-2.jpg</cover>
+    <api_id>6339</api_id>
+  </Game>
+  <Game>
+    <name>Wheel of Fortune</name>
+    <players>3</players>
+    <simultaneous>0</simultaneous>
+    <crc>1c384b11</crc>
+    <date>1992-01-01</date>
+    <publisher>Gametek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2766-1.jpg</cover>
+    <api_id>2766</api_id>
+  </Game>
+  <Game>
+    <name>Wheel of Fortune - Deluxe Edition</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>d6a5984c</crc>
+    <date>1994-04-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/9983-1.jpg</cover>
+    <api_id>9983</api_id>
+  </Game>
+  <Game>
+    <name>Where in the World Is Carmen Sandiego</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>9ef83223</crc>
+    <date>1993-06-01</date>
+    <publisher>EA Games</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/10959-1.jpg</cover>
+    <api_id>10959</api_id>
+  </Game>
+  <Game>
+    <name>Where in Time Is Carmen Sandiego</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1712018b</crc>
+    <date>1992-01-01</date>
+    <publisher>Hi Tech Expressions</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6343-1.jpg</cover>
+    <api_id>6343</api_id>
+  </Game>
+  <Game>
+    <name>Whirlo</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7379e3b3</crc>
+    <date>1992-01-01</date>
+    <publisher>Namco</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2215-1.jpg</cover>
+    <api_id>2215</api_id>
+  </Game>
+  <Game>
+    <name>Whizz</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>ea8df334</crc>
+    <date>1996-01-01</date>
+    <publisher>PMR</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6344-1.jpg</cover>
+    <api_id>6344</api_id>
+  </Game>
+  <Game>
+    <name>Wild Guns</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>085d8d14</crc>
+    <date>1995-07-01</date>
+    <publisher>Natsume</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2086-1.jpg</cover>
+    <api_id>2086</api_id>
+  </Game>
+  <Game>
+    <name>WildSnake</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>025adbf9</crc>
+    <date>1994-01-01</date>
+    <publisher>Spectrum Holobyte</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6346-1.jpg</cover>
+    <api_id>6346</api_id>
+  </Game>
+  <Game>
+    <name>Wing Commander</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>65ad4f8d</crc>
+    <date>1992-02-07</date>
+    <publisher>Mindscape</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2657-1.jpg</cover>
+    <api_id>2657</api_id>
+  </Game>
+  <Game>
+    <name>Wing Commander - The Secret Missions</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d5e9af7f</crc>
+    <date>1993-10-22</date>
+    <publisher>Mindscape</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6348-1.jpg</cover>
+    <api_id>6348</api_id>
+  </Game>
+  <Game>
+    <name>Wings 2 - Aces High</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>1637d1a5</crc>
+    <date>1992-10-01</date>
+    <publisher>Namco Limited</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3289-1.jpg</cover>
+    <api_id>3289</api_id>
+  </Game>
+  <Game>
+    <name>Winter Gold</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0f8378a6</crc>
+    <date>1996-01-01</date>
+    <publisher>Nintendo</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6349-1.jpg</cover>
+    <api_id>6349</api_id>
+  </Game>
+  <Game>
+    <name>Winter Olympic Games - Lillehammer '94</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>0704abe4</crc>
+    <date>1993-01-01</date>
+    <publisher>U.S. Gold</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6350-1.jpg</cover>
+    <api_id>6350</api_id>
+  </Game>
+  <Game>
+    <name>Wizard of Oz, The</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d5ce2db5</crc>
+    <date>1993-01-01</date>
+    <publisher>Seta</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6295-1.jpg</cover>
+    <api_id>6295</api_id>
+  </Game>
+  <Game>
+    <name>Wizardry V - Heart of the Maelstrom</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d8fddd76</crc>
+    <date>1994-04-01</date>
+    <publisher>Capcom</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3290-1.jpg</cover>
+    <api_id>3290</api_id>
+  </Game>
+  <Game>
+    <name>Wolfchild</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>13bfb3a0</crc>
+    <date>1992-01-01</date>
+    <publisher>Virgin Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2674-1.jpg</cover>
+    <api_id>2674</api_id>
+  </Game>
+  <Game>
+    <name>Wolfenstein 3D</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>6582a8f5</crc>
+    <date>1994-03-01</date>
+    <publisher>Imagineer</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2087-2.png</cover>
+    <api_id>2087</api_id>
+  </Game>
+  <Game>
+    <name>Wolverine - Adamantium Rage</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>4e62d6bf</crc>
+    <date>1994-11-28</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3915-1.jpg</cover>
+    <api_id>3915</api_id>
+  </Game>
+  <Game>
+    <name>Wordtris</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>856ab0bb</crc>
+    <date>1992-01-01</date>
+    <publisher>Spectrum Holobyte</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6353-1.jpg</cover>
+    <api_id>6353</api_id>
+  </Game>
+  <Game>
+    <name>World Class Rugby</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>d73d6c80</crc>
+    <date>1993-01-01</date>
+    <publisher>Audiogenic Software</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6354-1.jpg</cover>
+    <api_id>6354</api_id>
+  </Game>
+  <Game>
+    <name>World Cup Striker</name>
+    <players/>
+    <simultaneous/>
+    <crc>6d16f5e7</crc>
+    <date>1994</date>
+    <publisher>Elite</publisher>
+    <region>Europe</region>
+    <cover/>
+  </Game>
+  <Game>
+    <name>World Cup USA 94</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>fb1c9082</crc>
+    <date>1994-01-01</date>
+    <publisher>Mindscape Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6356-1.jpg</cover>
+    <api_id>6356</api_id>
+  </Game>
+  <Game>
+    <name>World Heroes</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>1228ad30</crc>
+    <date>1993-01-01</date>
+    <publisher>ADK</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2760-1.jpg</cover>
+    <api_id>2760</api_id>
+  </Game>
+  <Game>
+    <name>World Heroes 2</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>098d7eaa</crc>
+    <date>1994-01-01</date>
+    <publisher>Takara</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6357-1.jpg</cover>
+    <api_id>6357</api_id>
+  </Game>
+  <Game>
+    <name>World League Soccer</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>591cbb2d</crc>
+    <date>1991-01-01</date>
+    <publisher>Mindscape Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6359-1.jpg</cover>
+    <api_id>6359</api_id>
+  </Game>
+  <Game>
+    <name>World Masters Golf</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>e0ee681f</crc>
+    <date>1995-01-01</date>
+    <publisher>Virgin Interactive</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6360-1.jpg</cover>
+    <api_id>6360</api_id>
+  </Game>
+  <Game>
+    <name>World Soccer 94 - Road to Glory</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>0aae0a10</crc>
+    <date>1993-12-01</date>
+    <publisher>Atlus</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/9254-1.jpg</cover>
+    <api_id>9254</api_id>
+  </Game>
+  <Game>
+    <name>Worms</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>90d0fac0</crc>
+    <date>1995-01-01</date>
+    <publisher>Konami</publisher>
+    <region>Europe</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6362-1.jpg</cover>
+    <api_id>6362</api_id>
+  </Game>
+  <Game>
+    <name>WWF Raw</name>
+    <players>4+</players>
+    <simultaneous>0</simultaneous>
+    <crc>3e0038bf</crc>
+    <date>1994-11-25</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6363-1.jpg</cover>
+    <api_id>6363</api_id>
+  </Game>
+  <Game>
+    <name>WWF Royal Rumble</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>2101d515</crc>
+    <date>1993-01-01</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6364-2.jpg</cover>
+    <api_id>6364</api_id>
+  </Game>
+  <Game>
+    <name>WWF Super WrestleMania</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>676cb638</crc>
+    <date>1992-03-06</date>
+    <publisher>LJN</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3279-1.jpg</cover>
+    <api_id>3279</api_id>
+  </Game>
+  <Game>
+    <name>WWF WrestleMania - The Arcade Game</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>1ba08495</crc>
+    <date>1995-01-01</date>
+    <publisher>Cosmo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6365-1.jpg</cover>
+    <api_id>6365</api_id>
+  </Game>
+  <Game>
+    <name>X Zone</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>99627bb0</crc>
+    <date>1992-11-01</date>
+    <publisher>Kemco</publisher>
+    <region>Japan, USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/8184-1.jpg</cover>
+    <api_id>8184</api_id>
+  </Game>
+  <Game>
+    <name>X-Kaliber 2097</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>e83eceea</crc>
+    <date>1994-01-01</date>
+    <publisher>Sony</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6367-1.jpg</cover>
+    <api_id>6367</api_id>
+  </Game>
+  <Game>
+    <name>X-Men - Mutant Apocalypse</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>5e34822a</crc>
+    <date>1994-01-01</date>
+    <publisher>Avalon</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3291-1.jpg</cover>
+    <api_id>3291</api_id>
+  </Game>
+  <Game>
+    <name>Xardion</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>c7c12a57</crc>
+    <date>1992-01-01</date>
+    <publisher>Asmik Ace Entertainment Inc.</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6366-1.jpg</cover>
+    <api_id>6366</api_id>
+  </Game>
+  <Game>
+    <name>Yoshi's Cookie</name>
+    <players>2</players>
+    <simultaneous>0</simultaneous>
+    <crc>ef15f4c3</crc>
+    <date>1993-06-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6368-1.jpg</cover>
+    <api_id>6368</api_id>
+  </Game>
+  <Game>
+    <name>Yoshi's Safari</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>59490ce8</crc>
+    <date>1993-09-01</date>
+    <publisher>Nintendo</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/2088-1.jpg</cover>
+    <api_id>2088</api_id>
+  </Game>
+  <Game>
+    <name>Young Merlin</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>7ea1afe8</crc>
+    <date>1994-03-01</date>
+    <publisher>Virgin Interactive</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6369-1.png</cover>
+    <api_id>6369</api_id>
+  </Game>
+  <Game>
+    <name>Ys III - Wanderers from Ys</name>
+    <players/>
+    <simultaneous>0</simultaneous>
+    <crc>64a91e64</crc>
+    <date>1991-09-27</date>
+    <publisher>American Sammy</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/3292-1.jpg</cover>
+    <api_id>3292</api_id>
+  </Game>
+  <Game>
+    <name>Zero the Kamikaze Squirrel</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>5397d5bc</crc>
+    <date>1994-01-01</date>
+    <publisher>Mitsui</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6371-1.jpg</cover>
+    <api_id>6371</api_id>
+  </Game>
+  <Game>
+    <name>Zombies Ate My Neighbors</name>
+    <players>2</players>
+    <simultaneous>1</simultaneous>
+    <crc>7cfc0c7c</crc>
+    <date>1993-09-01</date>
+    <publisher>Konami</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/1361-1.jpg</cover>
+    <api_id>1361</api_id>
+  </Game>
+  <Game>
+    <name>Zool - Ninja of the Nth Dimension</name>
+    <players>1</players>
+    <simultaneous>0</simultaneous>
+    <crc>3c10daf1</crc>
+    <date>1994-01-01</date>
+    <publisher>GameTek</publisher>
+    <region>USA</region>
+    <cover>http://thegamesdb.net/banners/boxart/original/front/6373-1.jpg</cover>
+    <api_id>6373</api_id>
+  </Game>
+</Data>


### PR DESCRIPTION
Similar to nescarts.xml, this create a SNES database.

Resources used: 
https://github.com/eesperan/hyperspin-config/blob/master/Databases/Super%20Nintendo%20Entertainment%20System/All%20Game.xml for checksum mapping to names and region.
http://wiki.thegamesdb.net/index.php/API_Introduction for additional information (release date, cover art, number of players, publisher etc)

I've correct some names to get better mapping, it misses only a few checksums from the API, but 776 games are included.

I've tested this with a few roms and it does seem to match.

Ofcourse this isn't useful without additional code, but it's a start.