### PR TITLE
Fix small image resizing quality

### DIFF
--- a/Apps/NesMiniApplication.cs
+++ b/Apps/NesMiniApplication.cs
@@ -406,9 +406,16 @@ namespace com.clusterrr.hakchi_gui
             gr.Flush();
             outImage.Save(IconPath, ImageFormat.Png);
             gr = Graphics.FromImage(outImageSmall);
+
+            // Better resizing quality (more blur like original files)
+            gr.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
             gr.CompositingQuality = System.Drawing.Drawing2D.CompositingQuality.HighQuality;
-            gr.DrawImage(outImage, new Rectangle(0, 0, outImageSmall.Width, outImageSmall.Height),
-                new Rectangle(0, 0, outImage.Width, outImage.Height), GraphicsUnit.Pixel);
+            // Fix first line and column alpha shit
+            using (ImageAttributes wrapMode = new ImageAttributes())
+            {
+                wrapMode.SetWrapMode(System.Drawing.Drawing2D.WrapMode.TileFlipXY);
+                gr.DrawImage(outImage, new Rectangle(0, 0, outImageSmall.Width, outImageSmall.Height), 0, 0, outImage.Width, outImage.Height, GraphicsUnit.Pixel, wrapMode);
+            }
             gr.Flush();
             outImageSmall.Save(SmallIconPath, ImageFormat.Png);
         }


### PR DESCRIPTION
Small images were too pixelated, this modification enables smoother resizing and fixes the first line and column of pixels on the small images which appear as alpha / transparent