### PR TITLE
Extra Space for Games

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -784,7 +784,7 @@ namespace com.clusterrr.hakchi_gui
                 string prefix = "~";
                 if (WorkerForm.NandCTotal > 0)
                 {
-                    maxGamesSize = (WorkerForm.NandCFree + WorkerForm.WritedGamesSize) - WorkerForm.ReservedMemory * 1024 * 1024;
+                    maxGamesSize = ((WorkerForm.extraFs ? WorkerForm.NandEFree : 0) + WorkerForm.NandCFree + WorkerForm.WritedGamesSize) - WorkerForm.ReservedMemory * 1024 * 1024;
                     prefix = "";
                 }
                 toolStripStatusLabelSelected.Text = stats.Count + " " + Resources.GamesSelected;

--- a/WorkerForm.cs
+++ b/WorkerForm.cs
@@ -82,7 +82,8 @@ namespace com.clusterrr.hakchi_gui
         const long maxCompressedsRamfsSize = 30 * 1024 * 1024;
         string selectedFile = null;
         public NesMiniApplication[] addedApplications;
-        public static int NandCTotal, NandCUsed, NandCFree, WritedGamesSize, SaveStatesSize;
+        public static int NandCTotal, NandCUsed, NandCFree, NandETotal, NandEUsed, NandEFree, WritedGamesSize, SaveStatesSize;
+        public static bool extraFs = false;
         public static bool ExternalSaves = false;
         public static long ReservedMemory
         {
@@ -736,21 +737,54 @@ namespace com.clusterrr.hakchi_gui
             throw new NotImplementedException();
         }
 
+        public class NandStat
+        {
+            public int totalBytes = 0;
+            public int usedBytes = 0;
+            public int freeBytes = 0;
+            public NandStat(string device)
+            {
+                var clovershell = MainForm.Clovershell;
+                var nand = clovershell.ExecuteSimple("df | grep " + device + " | tail -n 1 | awk '{ print $2 \" | \" $3 \" | \" $4 }'", 500, true).Split('|');
+                if (nand.Length >= 3)
+                {
+                    totalBytes = int.Parse(nand[0]) * 1024;
+                    usedBytes = int.Parse(nand[1]) * 1024;
+                    freeBytes = int.Parse(nand[2]) * 1024;
+                }
+            }
+        }
+
         public static void GetMemoryStats()
         {
             var clovershell = MainForm.Clovershell;
-            var nandc = clovershell.ExecuteSimple("df /dev/nandc | tail -n 1 | awk '{ print $2 \" | \" $3 \" | \" $4 }'", 500, true).Split('|');
+            NandStat nandc = new NandStat("/dev/nandc");
+            NandStat nande = new NandStat("/dev/nande");
+            extraFs = clovershell.ExecuteSimple("df").Contains("/var/lib/hakchi/extrafs");
+
             ExternalSaves = clovershell.ExecuteSimple("mount | grep /var/lib/clover").Trim().Length > 0;
             WritedGamesSize = int.Parse(clovershell.ExecuteSimple("mkdir -p /var/lib/hakchi/rootfs/usr/share/games/ && du -s /var/lib/hakchi/rootfs/usr/share/games/ | awk '{ print $1 }'", 1000, true)) * 1024;
+            
+            if (extraFs)
+            {
+                WritedGamesSize += int.Parse(clovershell.ExecuteSimple("mkdir -p /var/lib/hakchi/extrafs/games/ && du -s /var/lib/hakchi/extrafs/games/ | awk '{ print $1 }'", 1000, true)) * 1024;
+            }
+
             SaveStatesSize = int.Parse(clovershell.ExecuteSimple("mkdir -p /var/lib/clover/profiles/0/ && du -s /var/lib/clover/profiles/0/ | awk '{ print $1 }'", 1000, true)) * 1024;
-            NandCTotal = int.Parse(nandc[0]) * 1024;
-            NandCUsed = int.Parse(nandc[1]) * 1024;
-            NandCFree = int.Parse(nandc[2]) * 1024;
+            NandCTotal = nandc.totalBytes;
+            NandCUsed = nandc.usedBytes;
+            NandCFree = nandc.freeBytes;
+
+            NandETotal = nande.totalBytes;
+            NandEUsed = nande.usedBytes;
+            NandEFree = nande.freeBytes;
+
             Debug.WriteLine(string.Format("NANDC size: {0:F1}MB, used: {1:F1}MB, free: {2:F1}MB", NandCTotal / 1024.0 / 1024.0, NandCUsed / 1024.0 / 1024.0, NandCFree / 1024.0 / 1024.0));
+            Debug.WriteLine(string.Format("NANDE size: {0:F1}MB, used: {1:F1}MB, free: {2:F1}MB", NandETotal / 1024.0 / 1024.0, NandEUsed / 1024.0 / 1024.0, NandEFree / 1024.0 / 1024.0));
             Debug.WriteLine(string.Format("Used by games: {0:F1}MB", WritedGamesSize / 1024.0 / 1024.0));
             Debug.WriteLine(string.Format("Used by save-states: {0:F1}MB", SaveStatesSize / 1024.0 / 1024.0));
             Debug.WriteLine(string.Format("Used by other files (mods, configs, etc.): {0:F1}MB", (NandCUsed - WritedGamesSize - SaveStatesSize) / 1024.0 / 1024.0));
-            Debug.WriteLine(string.Format("Available for games: {0:F1}MB", (NandCFree + WritedGamesSize) / 1024.0 / 1024.0));
+            Debug.WriteLine(string.Format("Available for games: {0:F1}MB", ((extraFs ? NandEFree : 0) + NandCFree + WritedGamesSize) / 1024.0 / 1024.0));
         }
 
         public static void ShowSplashScreen()
@@ -770,12 +804,36 @@ namespace com.clusterrr.hakchi_gui
             }
         }
 
+        public List<FolderInfo> GetGameFolderSizes(string basePath)
+        {
+            List<FolderInfo> folderSizes = new List<FolderInfo>();
+            string[] dirs = Directory.GetDirectories(basePath, "CLV-*", SearchOption.AllDirectories);
+            foreach (string dir in dirs)
+            {
+                long dirSize = 0;
+                TarStream tar = new TarStream(dir);
+                dirSize = tar.Length;
+                tar.Close();
+                tar.Dispose();
+                //foreach (string file in Directory.GetFiles(dir))
+                //{
+                    //FileInfo info = new FileInfo(file);
+                    //dirSize += info.Length;
+                //}
+                folderSizes.Add(new FolderInfo(dir.Substring(basePath.Length + 1), dirSize));
+            }
+            folderSizes.Sort((x, y) => y.size.CompareTo(x.size));
+            return folderSizes;
+        }
+
         public void UploadGames()
         {
             string gamesPath = NesMiniApplication.GamesCloverPath;
             const string rootFsPath = "/var/lib/hakchi/rootfs";
             const string installPath = "/var/lib/hakchi";
             const string squashFsPath = "/var/lib/hakchi/squashfs";
+            const string extraFsPath = "/var/lib/hakchi/extrafs";
+            const string extraGamesPath = extraFsPath + "/games";
             int progress = 0;
             int maxProgress = 400;
             if (Games == null || Games.Count == 0)
@@ -822,7 +880,7 @@ namespace com.clusterrr.hakchi_gui
                 SetProgress(progress, maxProgress);
 
                 GetMemoryStats();
-                var maxGamesSize = (NandCFree + WritedGamesSize) - ReservedMemory * 1024 * 1024;
+                var maxGamesSize = ((extraFs ? NandEFree : 0) + NandCFree + WritedGamesSize) - ReservedMemory * 1024 * 1024;
                 if (stats.TotalSize > maxGamesSize)
                 {
                     throw new Exception(string.Format(Resources.MemoryFull, stats.TotalSize / 1024 / 1024) + "\r\n\r\n" +
@@ -832,27 +890,60 @@ namespace com.clusterrr.hakchi_gui
                         SaveStatesSize / 1024.0 / 1024.0,
                         (NandCUsed - WritedGamesSize - SaveStatesSize) / 1024.0 / 1024.0));
                 }
-
                 int startProgress = progress;
-                using (var gamesTar = new TarStream(tempGamesDirectory))
+
+                clovershell.ExecuteSimple(string.Format("umount {0}", gamesPath));
+                clovershell.ExecuteSimple(string.Format("rm -rf {0}{1}/CLV-* {0}{1}/??? {2}/menu", rootFsPath, gamesPath, installPath), 5000, true);
+                if (extraFs)
                 {
-                    maxProgress = (int)(gamesTar.Length / 1024 / 1024 + 20 + originalGames.Count() * 2);
-                    SetProgress(progress, maxProgress);
+                    clovershell.ExecuteSimple(string.Format("rm -rf {0}", extraGamesPath));
+                }
 
-                    clovershell.ExecuteSimple(string.Format("umount {0}", gamesPath));
-                    clovershell.ExecuteSimple(string.Format("rm -rf {0}{1}/CLV-* {0}{1}/??? {2}/menu", rootFsPath, gamesPath, installPath), 5000, true);
+                List<FolderInfo> gameFolderSizes = GetGameFolderSizes(tempGamesDirectory);
+                maxProgress = 20 + originalGames.Count() * 2;
 
-                    if (gamesTar.Length > 0)
+                foreach (FolderInfo gameFolder in gameFolderSizes)
+                {
+                    maxProgress += (int)(gameFolder.size / 1024 / 1024 * 2);
+                }
+
+                foreach (FolderInfo gameFolder in gameFolderSizes)
+                {
+                    gameFolder.path = gameFolder.path.Replace("\\", "/");
+                    string baseDir = "";
+                    if (gameFolder.path.Contains("/"))
                     {
-                        gamesTar.OnReadProgress += delegate (long pos, long len)
-                        {
-                            progress = (int)(startProgress + pos / 1024 / 1024);
-                            SetProgress(progress, maxProgress);
-                        };
-
-                        SetStatus(Resources.UploadingGames);
-                        clovershell.Execute(string.Format("tar -xvC {0}{1}", rootFsPath, gamesPath), gamesTar, null, null, 30000, true);
+                        baseDir = gameFolder.path.Substring(0, gameFolder.path.LastIndexOf("/"));
                     }
+
+                    using (var gamesTar = new TarStream(Path.Combine(tempGamesDirectory, gameFolder.path)))
+                    {
+                        SetProgress(progress, maxProgress);
+
+                        if (gamesTar.Length > 0)
+                        {
+                            gamesTar.OnReadProgress += delegate (long pos, long len)
+                            {
+                                progress = (int)(startProgress + pos / 1024 / 1024);
+                                SetProgress(progress, maxProgress);
+                            };
+
+                            NandStat extraFsStats = new NandStat("/dev/nande");
+
+                            SetStatus(Resources.UploadingGames);
+                            clovershell.ExecuteSimple(string.Format("mkdir -p {0}{1}/{2}", rootFsPath, gamesPath, gameFolder.path), 30000, true);
+                            if (extraFs && extraFsStats.freeBytes - 102400 > gameFolder.size)
+                            {
+                                clovershell.ExecuteSimple(string.Format("mkdir -p {0}/{1}", extraGamesPath, gameFolder.path), 30000, true);
+                                clovershell.Execute(string.Format("tar -xvC {0}/{1}", extraGamesPath, gameFolder.path), gamesTar, null, null, 30000, true);
+                                clovershell.ExecuteSimple(string.Format("ln -s {0}/{1}/* {2}{3}/{4}/", extraGamesPath, gameFolder.path, rootFsPath, gamesPath, gameFolder.path), 30000, true);
+                            } else
+                            {
+                                clovershell.Execute(string.Format("tar -xvC {0}{1}/{2}", rootFsPath, gamesPath, gameFolder.path), gamesTar, null, null, 30000, true);
+                            }
+                        }
+                    }
+                    startProgress = progress;
                 }
 
                 SetStatus(Resources.UploadingOriginalGames);
@@ -1163,6 +1254,17 @@ namespace com.clusterrr.hakchi_gui
             public int TotalGames = 0;
             public long TotalSize = 0;
             public long TransferSize = 0;
+        }
+
+        public class FolderInfo
+        {
+            public string path = "";
+            public long size = 0;
+            public FolderInfo(string path, long size)
+            {
+                this.path = path;
+                this.size = size;
+            }
         }
 
         private void AddMenu(NesMenuCollection menuCollection, Dictionary<string, string> originalGames, GamesTreeStats stats = null)

--- a/hakchi_gui.csproj
+++ b/hakchi_gui.csproj
@@ -608,6 +608,9 @@
     <Content Include="user_mods\extra_space.hmod\readme.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="user_mods\extra_space_for_games.hmod\readme.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="user_mods\snes_custom_filters.hmod\readme.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -2138,6 +2141,15 @@
     <Content Include="user_mods\extra_space.hmod\uninstall">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="user_mods\extra_space_for_games.hmod\etc\preinit.d\p7120_extra_space_for_games">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="user_mods\extra_space_for_games.hmod\install">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="user_mods\extra_space_for_games.hmod\uninstall">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="data\GameGenieDB.xml">
@@ -2525,32 +2537,32 @@
   <ItemGroup>
     <PublishFile Include="data\GameGenieDB.xml">
       <Visible>False</Visible>
-      <PublishState>Include</PublishState>
-      <IncludeHash>True</IncludeHash>
       <Group>
       </Group>
       <TargetPath>
       </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
     <PublishFile Include="data\nescarts.xml">
       <Visible>False</Visible>
-      <PublishState>Include</PublishState>
-      <IncludeHash>True</IncludeHash>
       <Group>
       </Group>
       <TargetPath>
       </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
     <PublishFile Include="data\snescarts.xml">
       <Visible>False</Visible>
-      <PublishState>Include</PublishState>
-      <IncludeHash>True</IncludeHash>
       <Group>
       </Group>
       <TargetPath>
       </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
   </ItemGroup>

--- a/user_mods/extra_space_for_games.hmod/etc/preinit.d/p7120_extra_space_for_games
+++ b/user_mods/extra_space_for_games.hmod/etc/preinit.d/p7120_extra_space_for_games
@@ -1,0 +1,5 @@
+local ext_device="/dev/nande"
+local ext_path="$installpath/extrafs"
+mkdir -p $ext_path
+echo mounting $ext_path
+mount -o rw,nosuid,nodev,noatime "$ext_device" "$ext_path"

--- a/user_mods/extra_space_for_games.hmod/install
+++ b/user_mods/extra_space_for_games.hmod/install
@@ -1,0 +1,11 @@
+local ext_device="/dev/nande"
+local ext_path="$installpath/extrafs"
+mkdir -p $ext_path
+
+if ! mount -o rw,nosuid,nodev,noatime "$ext_device" "$ext_path" ; then
+  echo creating fs on $ext_device
+  $rootfs/bin/mkfs.ext2 "$ext_device" || return 1
+  mount -o rw,nosuid,nodev,noatime "$ext_device" "$ext_path" || return 1
+fi
+
+return 0

--- a/user_mods/extra_space_for_games.hmod/readme.txt
+++ b/user_mods/extra_space_for_games.hmod/readme.txt
@@ -1,0 +1,5 @@
+=== Extra Space For Games Hack ===
+
+This is VERY EXPERIMENTAL mod for SNES Mini which will allow hakchi to use an unused portion of the flash to store additional games on.
+
+This partition is only 50MB in size, but it should allow for a reasonable amount of additional games.

--- a/user_mods/extra_space_for_games.hmod/uninstall
+++ b/user_mods/extra_space_for_games.hmod/uninstall
@@ -1,0 +1,5 @@
+local ext_device="/dev/nande"
+local ext_path="$installpath/extrafs"
+umount "$ext_path"
+rm "$preinitpath/p7120_extra_space_for_games"
+rm -rf "$ext_path"


### PR DESCRIPTION
This pull request contains a mod that mounts /dev/nande to /var/lib/hakchi/extrafs and also includes changes that enable hakchi to sync games to that space until full.

I tried to rebase this on top of your latest commit, but upon building trying to sync, it rebooted into a boot loop with no clovercon.

I tried to reflash to the stock kernel and back, still had a boot loop...

But anyways, this build and custom kernel both work for me, I have a European SNES Classic if it matters.

@ClusterM When / if the extra space mod is determined safe, I'd imagine it could be built into the kernel instead of a separate hmod, but that would require checking the board type and if /dev/nande even exists, not to mention removing the other extra space mod...

On another note, can I execute the uninstall script for another mod during installation of this mod?