### PR TITLE
Install games to both extra space and main (Based on 2.21c)

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -800,7 +800,7 @@ namespace com.clusterrr.hakchi_gui
                 var maxGamesSize = DefaultMaxGamesSize * 1024 * 1024;
                 if (WorkerForm.NandCTotal > 0)
                 {
-                    maxGamesSize = (WorkerForm.NandCFree + WorkerForm.WritedGamesSize) - WorkerForm.ReservedMemory * 1024 * 1024;
+                    maxGamesSize = ((WorkerForm.extraFs ? WorkerForm.NandEFree : 0) + WorkerForm.NandCFree + WorkerForm.WritedGamesSize) - WorkerForm.ReservedMemory * 1024 * 1024;
                     toolStripStatusLabelSize.Text = string.Format("{0:F1}MB / {1:F1}MB", stats.Size / 1024.0 / 1024.0, maxGamesSize / 1024.0 / 1024.0);
                 }
                 else

--- a/hakchi_gui.csproj
+++ b/hakchi_gui.csproj
@@ -609,6 +609,9 @@
     <Content Include="user_mods\extra_space.hmod\readme.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="user_mods\extra_space_for_games.hmod\readme.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="user_mods\snes_custom_filters.hmod\readme.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -2175,6 +2178,15 @@
     <Content Include="user_mods\extra_space.hmod\uninstall">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="user_mods\extra_space_for_games.hmod\etc\preinit.d\p7120_extra_space_for_games">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="user_mods\extra_space_for_games.hmod\install">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="user_mods\extra_space_for_games.hmod\uninstall">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="data\GameGenieDB.xml">
@@ -2562,32 +2574,32 @@
   <ItemGroup>
     <PublishFile Include="data\GameGenieDB.xml">
       <Visible>False</Visible>
-      <PublishState>Include</PublishState>
-      <IncludeHash>True</IncludeHash>
       <Group>
       </Group>
       <TargetPath>
       </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
     <PublishFile Include="data\nescarts.xml">
       <Visible>False</Visible>
-      <PublishState>Include</PublishState>
-      <IncludeHash>True</IncludeHash>
       <Group>
       </Group>
       <TargetPath>
       </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
     <PublishFile Include="data\snescarts.xml">
       <Visible>False</Visible>
-      <PublishState>Include</PublishState>
-      <IncludeHash>True</IncludeHash>
       <Group>
       </Group>
       <TargetPath>
       </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
   </ItemGroup>

--- a/user_mods/extra_space_for_games.hmod/etc/preinit.d/p7120_extra_space_for_games
+++ b/user_mods/extra_space_for_games.hmod/etc/preinit.d/p7120_extra_space_for_games
@@ -1,0 +1,5 @@
+local ext_device="/dev/nande"
+local ext_path="$installpath/extrafs"
+mkdir -p $ext_path
+echo mounting $ext_path
+mount -o rw,nosuid,nodev,noatime "$ext_device" "$ext_path"

--- a/user_mods/extra_space_for_games.hmod/install
+++ b/user_mods/extra_space_for_games.hmod/install
@@ -1,0 +1,11 @@
+local ext_device="/dev/nande"
+local ext_path="$installpath/extrafs"
+mkdir -p $ext_path
+
+if ! mount -o rw,nosuid,nodev,noatime "$ext_device" "$ext_path" ; then
+  echo creating fs on $ext_device
+  $rootfs/bin/mkfs.ext2 "$ext_device" || return 1
+  mount -o rw,nosuid,nodev,noatime "$ext_device" "$ext_path" || return 1
+fi
+
+return 0

--- a/user_mods/extra_space_for_games.hmod/readme.txt
+++ b/user_mods/extra_space_for_games.hmod/readme.txt
@@ -1,0 +1,5 @@
+=== Extra Space For Games Hack ===
+
+This is VERY EXPERIMENTAL mod for SNES Mini which will allow hakchi to use an unused portion of the flash to store additional games on.
+
+This partition is only 50MB in size, but it should allow for a reasonable amount of additional games.

--- a/user_mods/extra_space_for_games.hmod/uninstall
+++ b/user_mods/extra_space_for_games.hmod/uninstall
@@ -1,0 +1,5 @@
+local ext_device="/dev/nande"
+local ext_path="$installpath/extrafs"
+umount "$ext_path"
+rm "$preinitpath/p7120_extra_space_for_games"
+rm -rf "$ext_path"


### PR DESCRIPTION
I know the last pull request was closed, I'm assuming that was because of bugs?

And @ClusterM, If you close this one, please say why...

But here it is again, but this time based on 2.21c

I've tested uninstalling and reinstall the accompanying mod multiple times as well as flashing to stock and custom kernels multiple times.

This code checks if /var/lib/hakchi/extrafs is mounted to /dev/nande and will span games across both partitions linking as needed during sync, if extrafs isn't mounted, it syncs like before.

Any thoughts @madmonkey1907 ?

Here's a compiled version for testing, I know @DecanFrost was interested.

[hakchi2.21c_dantheman827_more-space-for-games_debug.zip](https://github.com/ClusterM/hakchi2/files/1384437/hakchi2.21c_dantheman827_more-space-for-games_debug.zip)
