### PR TITLE
Don't delete any NES games that may exist when syncing

### DIFF
--- a/WorkerForm.cs
+++ b/WorkerForm.cs
@@ -896,7 +896,14 @@ namespace com.clusterrr.hakchi_gui
                         clovershell.ExecuteSimple($"[ -f \"{squashFsPath}{gamesPath}/title.fnt\" ] && [ ! -f \"{rootFsPath}{gamesPath}/title.fnt\" ] && cp -f \"{squashFsPath}{gamesPath}/title.fnt\" \"{rootFsPath}{gamesPath}\"/", 3000, false);
                         clovershell.ExecuteSimple($"[ -f \"{squashFsPath}{gamesPath}/copyright.fnt\" ] && [ ! -f \"{rootFsPath}{gamesPath}/copyright.fnt\" ] && cp -f \"{squashFsPath}{gamesPath}/copyright.fnt\" \"{rootFsPath}{gamesPath}\"/", 3000, false);
                     }
+
+                    if (ConfigIni.ConsoleType == MainForm.ConsoleType.SNES || ConfigIni.ConsoleType == MainForm.ConsoleType.SuperFamicom)
+                        clovershell.ExecuteSimple(string.Format("mv {0}{1}/nes {0}{1}/nes.temp", rootFsPath, gamesPath), 5000, false);
+
                     clovershell.ExecuteSimple(string.Format("rm -rf {0}{1}/CLV-* {0}{1}/??? {2}/menu", rootFsPath, gamesPath, installPath), 5000, true);
+
+                    if (ConfigIni.ConsoleType == MainForm.ConsoleType.SNES || ConfigIni.ConsoleType == MainForm.ConsoleType.SuperFamicom)
+                        clovershell.ExecuteSimple(string.Format("mv {0}{1}/nes.temp {0}{1}/nes", rootFsPath, gamesPath), 5000, false);
 
                     if (gamesTar.Length > 0)
                     {


### PR DESCRIPTION
A pretty simple change.

When syncing games to a SNES image, move the nes folder out of the way before running rm since {0}{1}/??? also matches the nes folder.

This is a problem if you switch between nand and another hsqs image