### PR TITLE
Per system games directories

### DIFF
--- a/Apps/NesMiniApplication.cs
+++ b/Apps/NesMiniApplication.cs
@@ -56,6 +56,24 @@ namespace com.clusterrr.hakchi_gui
                 }
             }
         }
+        public static string HakchiGamesPath
+        {
+            get
+            {
+                switch (ConfigIni.ConsoleType)
+                {
+                    default:
+                    case MainForm.ConsoleType.NES:
+                        return "/var/lib/hakchi/games/nes-usa/nes/kachikachi";
+                    case MainForm.ConsoleType.Famicom:
+                        return "/var/lib/hakchi/games/nes-jpn/nes/kachikachi";
+                    case MainForm.ConsoleType.SNES:
+                        return "/var/lib/hakchi/games/snes-usa";
+                    case MainForm.ConsoleType.SuperFamicom:
+                        return "/var/lib/hakchi/games/snes-jpn";
+                }
+            }
+        }
 
         protected string code;
         public string Code
@@ -248,7 +266,7 @@ namespace com.clusterrr.hakchi_gui
             game.Name = Regex.Replace(game.Name, @" ?\(.*?\)", string.Empty).Trim();
             game.Name = Regex.Replace(game.Name, @" ?\[.*?\]", string.Empty).Trim();
             game.Name = game.Name.Replace("_", " ").Replace("  ", " ").Trim();
-            game.Command = $"{application} {GamesCloverPath}/{code}/{outputFileName}";
+            game.Command = $"{application} {HakchiGamesPath}/{code}/{outputFileName}";
             if (!string.IsNullOrEmpty(args))
                 game.Command += " " + args;
             game.FindCover(inputFileName, cover, crc32);
@@ -357,7 +375,7 @@ namespace com.clusterrr.hakchi_gui
                 $"Exec={command}\n" +
                 $"Path=/var/lib/clover/profiles/0/{Code}\n" +
                 $"Name={Name ?? Code}\n" +
-                $"Icon={GamesCloverPath}/{Code}/{Code}.png\n\n" +
+                $"Icon={HakchiGamesPath}/{Code}/{Code}.png\n\n" +
                 $"[X-CLOVER Game]\n" +
                 $"Code={Code}\n" +
                 $"TestID=777\n" +

--- a/mods/mod_hakchi/hakchi/rootfs/etc/preinit.d/p7075_gamesbind
+++ b/mods/mod_hakchi/hakchi/rootfs/etc/preinit.d/p7075_gamesbind
@@ -1,0 +1,13 @@
+local realgamespath="$installpath/games/$sftype-$sfregion"
+
+if [ ! -d "$rootfs/usr/share/games" ]; then
+  mkdir -p "$rootfs/usr/share/games"
+fi
+
+if [ ! -d "$realgamespath" ]; then
+  mkdir -p "$(dirname $realgamespath)"
+  mv "$rootfs/usr/share/games" "$realgamespath"
+  mkdir -p "$rootfs/usr/share/games"
+fi
+
+mount -o bind "$installpath/games/$sftype-$sfregion" "$rootfs/usr/share/games"


### PR DESCRIPTION
This script will move the games directory to a system-specific one if needed and do a bind mount to $rootfs/usr/share/games

This will keep SNES and NES games separate when switching between images and also prevent hakchi from accidentally deleting games for the other system.

@ClusterM on a related note, the path that hakchi2 automatically chooses when adding hsqs files isn't correct.

It should be something like `/var/lib/hakchi/games/snes-usa/CLV-S-00NES/dp-nes.hsqs` instead of `/usr/share/games/CLV-S-00NES/dp-nes.hsqs` (well, at least with this script)

With this pull request, uncompressed (not 7z) hsqs files can be added as a game and booted, although on a famicom, the controllers don't work outside the stock software [according to a user on reddit](https://www.reddit.com/r/nesclassicmods/comments/76e0rq/guide_transform_your_nes_classic_mini_into_an/dofi5ba/?context=3)

I'm assuming that's because of not detecting the actual hardware, but rather what the hsqs says it _should_ be.