### PR TITLE
Multi-Boot Fixes

### DIFF
--- a/Apps/NesMiniApplication.cs
+++ b/Apps/NesMiniApplication.cs
@@ -56,24 +56,6 @@ namespace com.clusterrr.hakchi_gui
                 }
             }
         }
-        public static string HakchiGamesPath
-        {
-            get
-            {
-                switch (ConfigIni.ConsoleType)
-                {
-                    default:
-                    case MainForm.ConsoleType.NES:
-                        return "/var/lib/hakchi/games/nes-usa/nes/kachikachi";
-                    case MainForm.ConsoleType.Famicom:
-                        return "/var/lib/hakchi/games/nes-jpn/nes/kachikachi";
-                    case MainForm.ConsoleType.SNES:
-                        return "/var/lib/hakchi/games/snes-usa";
-                    case MainForm.ConsoleType.SuperFamicom:
-                        return "/var/lib/hakchi/games/snes-jpn";
-                }
-            }
-        }
 
         protected string code;
         public string Code
@@ -266,7 +248,7 @@ namespace com.clusterrr.hakchi_gui
             game.Name = Regex.Replace(game.Name, @" ?\(.*?\)", string.Empty).Trim();
             game.Name = Regex.Replace(game.Name, @" ?\[.*?\]", string.Empty).Trim();
             game.Name = game.Name.Replace("_", " ").Replace("  ", " ").Trim();
-            game.Command = $"{application} {HakchiGamesPath}/{code}/{outputFileName}";
+            game.Command = $"{application} {GamesCloverPath}/{code}/{outputFileName}";
             if (!string.IsNullOrEmpty(args))
                 game.Command += " " + args;
             game.FindCover(inputFileName, cover, crc32);
@@ -375,7 +357,7 @@ namespace com.clusterrr.hakchi_gui
                 $"Exec={command}\n" +
                 $"Path=/var/lib/clover/profiles/0/{Code}\n" +
                 $"Name={Name ?? Code}\n" +
-                $"Icon={HakchiGamesPath}/{Code}/{Code}.png\n\n" +
+                $"Icon={GamesCloverPath}/{Code}/{Code}.png\n\n" +
                 $"[X-CLOVER Game]\n" +
                 $"Code={Code}\n" +
                 $"TestID=777\n" +

--- a/Apps/NesMiniApplication.cs
+++ b/Apps/NesMiniApplication.cs
@@ -666,6 +666,8 @@ namespace com.clusterrr.hakchi_gui
                     continue;
                 if (System.IO.Path.GetExtension(file).ToLower() == ".zip")
                     continue;
+                if (System.IO.Path.GetExtension(file).ToLower() == ".hsqs")
+                    continue;
                 if (exec.Contains(" " + System.IO.Path.GetFileName(file) + " "))
                     result.Add(file);
             }

--- a/Apps/NesMiniApplication.cs
+++ b/Apps/NesMiniApplication.cs
@@ -56,6 +56,24 @@ namespace com.clusterrr.hakchi_gui
                 }
             }
         }
+        public static string HakchiGamesPath
+        {
+            get
+            {
+                switch (ConfigIni.ConsoleType)
+                {
+                    default:
+                    case MainForm.ConsoleType.NES:
+                        return "/var/lib/hakchi/games/nes-usa/nes/kachikachi";
+                    case MainForm.ConsoleType.Famicom:
+                        return "/var/lib/hakchi/games/nes-jpn/nes/kachikachi";
+                    case MainForm.ConsoleType.SNES:
+                        return "/var/lib/hakchi/games/snes-usa";
+                    case MainForm.ConsoleType.SuperFamicom:
+                        return "/var/lib/hakchi/games/snes-jpn";
+                }
+            }
+        }
 
         protected string code;
         public string Code
@@ -248,7 +266,7 @@ namespace com.clusterrr.hakchi_gui
             game.Name = Regex.Replace(game.Name, @" ?\(.*?\)", string.Empty).Trim();
             game.Name = Regex.Replace(game.Name, @" ?\[.*?\]", string.Empty).Trim();
             game.Name = game.Name.Replace("_", " ").Replace("  ", " ").Trim();
-            game.Command = $"{application} {GamesCloverPath}/{code}/{outputFileName}";
+            game.Command = $"{application} {HakchiGamesPath}/{code}/{outputFileName}";
             if (!string.IsNullOrEmpty(args))
                 game.Command += " " + args;
             game.FindCover(inputFileName, cover, crc32);
@@ -357,7 +375,7 @@ namespace com.clusterrr.hakchi_gui
                 $"Exec={command}\n" +
                 $"Path=/var/lib/clover/profiles/0/{Code}\n" +
                 $"Name={Name ?? Code}\n" +
-                $"Icon={GamesCloverPath}/{Code}/{Code}.png\n\n" +
+                $"Icon={HakchiGamesPath}/{Code}/{Code}.png\n\n" +
                 $"[X-CLOVER Game]\n" +
                 $"Code={Code}\n" +
                 $"TestID=777\n" +

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -245,7 +245,7 @@ namespace com.clusterrr.hakchi_gui
                 MessageBoxManager.Cancel = Resources.NoForAll;
                 MessageBoxManager.Abort = Resources.YesForAll;
 
-                var extensions = new List<string>() { "*.new", "*.unf", "*.unif", ".*fds", "*.desktop", "*.zip", "*.7z", "*.rar" };
+                var extensions = new List<string>() { "*.new", "*.unf", "*.unif", ".*fds", "*.desktop", "*.zip", "*.7z", "*.rar", "*.hsqs" };
                 foreach (var app in AppTypeCollection.ApplicationTypes)
                     foreach (var ext in app.Extensions)
                         if (!extensions.Contains("*" + ext))

--- a/hakchi_gui.csproj
+++ b/hakchi_gui.csproj
@@ -2251,6 +2251,12 @@
     <Content Include="mods\mod_hakchi\sbin\init">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="mods\mod_hakchi\hakchi\rootfs\etc\preinit.d\p7075_gamesbind">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="mods\mod_hakchi\hakchi\rootfs\etc\preinit.d\p7075_profilebind">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="Properties\app.manifest" />
     <Content Include="user_mods\snes_custom_filters.hmod\canoe-custom-filters">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -2660,32 +2666,32 @@
   <ItemGroup>
     <PublishFile Include="data\GameGenieDB.xml">
       <Visible>False</Visible>
-      <PublishState>Include</PublishState>
-      <IncludeHash>True</IncludeHash>
       <Group>
       </Group>
       <TargetPath>
       </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
     <PublishFile Include="data\nescarts.xml">
       <Visible>False</Visible>
-      <PublishState>Include</PublishState>
-      <IncludeHash>True</IncludeHash>
       <Group>
       </Group>
       <TargetPath>
       </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
     <PublishFile Include="data\snescarts.xml">
       <Visible>False</Visible>
-      <PublishState>Include</PublishState>
-      <IncludeHash>True</IncludeHash>
       <Group>
       </Group>
       <TargetPath>
       </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
   </ItemGroup>

--- a/mods/mod_hakchi/hakchi/rootfs/bin/hsqs
+++ b/mods/mod_hakchi/hakchi/rootfs/bin/hsqs
@@ -6,7 +6,11 @@ echo "current firmware: $(currentFirmware)"
 printSoftwareInfo
 
 firmware="$1"
-menu="$(cat /var/lib/hakchi/menu)"
+if [ -f "/var/lib/hakchi/menu/" ]; then
+  menu="$(cat /var/lib/hakchi/menu)"
+else
+  menu="000"
+fi
 
 if [ "$menu" == "000" ]; then
   menu=""

--- a/mods/mod_hakchi/hakchi/rootfs/bin/hsqs
+++ b/mods/mod_hakchi/hakchi/rootfs/bin/hsqs
@@ -6,8 +6,24 @@ echo "current firmware: $(currentFirmware)"
 printSoftwareInfo
 
 firmware="$1"
+menu="$(cat /var/lib/hakchi/menu)"
+
+if [ "$menu" == "000" ]; then
+  menu=""
+else
+  menu="$menu\\/"
+fi
+
+[ "$sftype" == "nes" ] && gamessuffix="nes\\/kachikachi\\/"
+ 
+echo "$firmware" | grep '^/usr/share/games/'
+
+if [ $? -eq 0 ]; then
+  firmware="`echo "$firmware" | sed -e "s/^\\/usr\\/share\\/games\\/$gamessuffix/\\/var\\/lib\\/hakchi\\/games\\/$sftype-$sfregion\\/$gamessuffix$menu/"`"
+fi
+
 if [ "$firmware" != "_nand_" ]; then
-  firmware="$(readlink -f "$1")"
+  firmware="$(readlink -f "$firmware")"
   checkFirmware "$firmware" || exit 1
 fi
 
@@ -18,5 +34,6 @@ save_config
 [ "$(currentFirmware)" == "$firmware" ] && exit 0
 
 echo "changing firmware to: $firmware"
+rm "/var/lib/hakchi/menu"
 reboot
 exit 0

--- a/mods/mod_hakchi/hakchi/rootfs/etc/init.d/S78clvcon
+++ b/mods/mod_hakchi/hakchi/rootfs/etc/init.d/S78clvcon
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CLV_BOARD_NAME=$(cat /etc/clover/boardtype)
+CLV_BOARD_NAME=$(cat "/var/lib/hakchi/boardtype")
 MODULE="clvcon"
 [ -f "/lib/modules/$(uname -r)/extra/$MODULE.ko" ] || MODULE="clovercon"
 

--- a/mods/mod_hakchi/hakchi/rootfs/etc/preinit.d/b0000_defines
+++ b/mods/mod_hakchi/hakchi/rootfs/etc/preinit.d/b0000_defines
@@ -31,3 +31,7 @@ gamepath=""
 temppath="/tmp"
 
 setGamepath
+
+echo "$sftype-$sfregion" > "$installpath/hardware-id"
+cat "$mountpoint/etc/clover/boardtype" > "$installpath/boardtype"
+cat "$mountpoint/etc/clover/REGION" > "$installpath/REGION"

--- a/mods/mod_hakchi/hakchi/rootfs/etc/preinit.d/b0010_functions
+++ b/mods/mod_hakchi/hakchi/rootfs/etc/preinit.d/b0010_functions
@@ -54,7 +54,7 @@ mod_repair_etc(){
 }
 
 mod_repair_modules(){
-  restore "/lib/modules/$(uname -r)/"
+  restore "/lib/modules/$(uname -r)/" "--exclude "*/clvcon.ko" --exclude "*/clovercon.ko""
 }
 
 remount_root(){
@@ -141,7 +141,7 @@ copy(){
   # we must create target directory
   local dirname="$(dirname "$2")"
   mkdir -p "$dirname"
-  rsync -ac "$1" "$2"
+  rsync -ac "$1" "$2" $3
 }
 
 copy_mask(){
@@ -153,9 +153,9 @@ copy_mask(){
 
 restore(){
   if mountpoint -q "$squashfs" && [ -e "$squashfs$1" ]; then
-    copy "$squashfs$1" "$rootfs$1"
+    copy "$squashfs$1" "$rootfs$1" "$2"
   else
-    copy "$mountpoint$1" "$rootfs$1"
+    copy "$mountpoint$1" "$rootfs$1" "$2"
   fi
 }
 

--- a/mods/mod_hakchi/hakchi/rootfs/etc/preinit.d/p7075_gamesbind
+++ b/mods/mod_hakchi/hakchi/rootfs/etc/preinit.d/p7075_gamesbind
@@ -1,0 +1,13 @@
+local realgamespath="$installpath/games/$sftype-$sfregion"
+
+if [ ! -d "$rootfs/usr/share/games" ]; then
+  mkdir -p "$rootfs/usr/share/games"
+fi
+
+if [ ! -d "$realgamespath" ]; then
+  mkdir -p "$(dirname $realgamespath)"
+  mv "$rootfs/usr/share/games" "$realgamespath"
+  mkdir -p "$rootfs/usr/share/games"
+fi
+
+mount -o bind "$installpath/games/$sftype-$sfregion" "$rootfs/usr/share/games"

--- a/mods/mod_hakchi/hakchi/rootfs/etc/preinit.d/p7075_profilebind
+++ b/mods/mod_hakchi/hakchi/rootfs/etc/preinit.d/p7075_profilebind
@@ -1,0 +1,15 @@
+local cloverpath="$mountpoint/var/lib/foreign-clover/$sftype-$sfregion"
+local hardwareid=$(cat "$mountpoint/var/lib/hakchi/hardware-id")
+
+if [ "$sftype-$sfregion" != "$hardwareid" ]; then
+  
+  if [ ! -d "$mountpoint/var/lib/clover" ]; then
+    mkdir -p "$mountpoint/var/lib/clover"
+  fi
+  
+  if [ ! -d "$cloverpath" ]; then
+    mkdir -p "$cloverpath"
+  fi
+
+  mount -o bind "$cloverpath" "$mountpoint/var/lib/clover"
+fi


### PR DESCRIPTION
Fixes are as follow:

**Exclude clovercon modules during mod_repair_modules**
This enables switching hsqs without breaking the controller hacks

**Separate game and clover directories based on the image type currently booted.**
This is needed because switching to a Japanese system and back caused a soft-brick in `ReedPlayer-Clover` until the `/var/lib/clover/` folder was deleted.

As a side-effect, this means that factory resets are also separate.

@ClusterM You may want to amend the save manager to look for saves in these directories as well so that users can manage them even if they're not booted into that image.

- `/var/lib/hakchi/foreign-clover/nes-usa/`
- `/var/lib/hakchi/foreign-clover/nes-jpn/`
- `/var/lib/hakchi/foreign-clover/snes-usa/`
- `/var/lib/hakchi/foreign-clover/snes-jpn/`

**Save a copy of the base hardware info to `/var/lib/hakchi/`, files include `boardtype`, `REGION`, and `hardware-id` (this is equal to `$sftype-$sfregion`)**
This information is needed from within the hsqs to properly configure clovercon, for example, booting the Famicom image on a SNES.

**Make hakchi2 use absolute game paths instead of `/usr/share/games`**
This makes it possible to sync a hsqs file as a "game" within hakchi and boot it.

@ClusterM when uninstalling hakchi, check for the presence of `/var/lib/foreign-clover/`, if it exists, ask the user if they want to erase the non-native saves.

[hakchi-2.21d-dantheman827-2c93f77.zip](https://github.com/ClusterM/hakchi2/files/1404545/hakchi-2.21d-dantheman827-2c93f77.zip)