### PR TITLE
Custom border manager

### DIFF
--- a/Apps/BorderElement.cs
+++ b/Apps/BorderElement.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace com.clusterrr.hakchi_gui.Apps
+{
+    class BorderElement
+    {
+        public static string BackgroundsDirectory
+        {
+            get
+            {
+                return System.IO.Path.Combine(Program.BaseDirectoryExternal, "backgrounds");
+            }
+        }
+
+        public BorderElement(string path)
+        {
+            String str = path;
+            Path = path;
+            Name = str.Substring(1+str.LastIndexOf(System.IO.Path.DirectorySeparatorChar));
+            IconPath = Path + System.IO.Path.DirectorySeparatorChar + Name + "_thumbnail.png";
+        }
+
+        private string iconPath;
+        public string IconPath { get => iconPath; set => iconPath = value; }
+
+        private string path;
+        public string Path { get => path; set => path = value; }
+
+        private string name;
+        public string Name
+        {
+            get { return name; }
+            set
+            {
+                name = value;
+            }
+        }
+
+        public static Bitmap LoadBitmap(string path)
+        {
+            //Open file in read only mode
+            using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read))
+            //Get a binary reader for the file stream
+            using (BinaryReader reader = new BinaryReader(stream))
+            {
+                //copy the content of the file into a memory stream
+                var memoryStream = new MemoryStream(reader.ReadBytes((int)stream.Length));
+                //make a new Bitmap object the owner of the MemoryStream
+                return new Bitmap(memoryStream);
+            }
+        }
+
+        internal static object FromDirectory(string borderDir)
+        {
+            BorderElement border = new BorderElement(borderDir);
+
+            return border;
+        }
+    }
+}

--- a/ConfigIni.cs
+++ b/ConfigIni.cs
@@ -8,8 +8,10 @@ namespace com.clusterrr.hakchi_gui
     public class ConfigIni
     {
         public static int RunCount = 0;
+        public static string SelectedBorders = "default";
         public static string SelectedGamesNes = "default";
         public static string SelectedGamesSnes = "default";
+        public static string HiddenGamesBorders = "";
         public static string HiddenGamesNes = "";
         public static string HiddenGamesFamicom = "";
         public static string HiddenGamesSnes = "";
@@ -434,11 +436,17 @@ namespace com.clusterrr.hakchi_gui
                                 case "language":
                                     Language = value;
                                     break;
+                                case "selectedborders":
+                                    SelectedBorders = value;
+                                    break;
                                 case "selectedgames":
                                     SelectedGamesNes = value;
                                     break;
                                 case "selectedgamessnes":
                                     SelectedGamesSnes = value;
+                                    break;
+                                case "hiddengamesborders":
+                                    HiddenGamesBorders = value;
                                     break;
                                 case "hiddengames":
                                     HiddenGamesNes = value;
@@ -565,8 +573,10 @@ namespace com.clusterrr.hakchi_gui
             var configLines = new List<string>();
             configLines.Add("[Config]");
             configLines.Add(string.Format("Language={0}", Language));
+            configLines.Add(string.Format("SelectedBorders={0}", SelectedBorders));
             configLines.Add(string.Format("SelectedGames={0}", SelectedGamesNes));
             configLines.Add(string.Format("SelectedGamesSnes={0}", SelectedGamesSnes));
+            configLines.Add(string.Format("HiddenGamesBorders={0}", HiddenGamesBorders));
             configLines.Add(string.Format("HiddenGames={0}", HiddenGamesNes));
             configLines.Add(string.Format("HiddenGamesFamicom={0}", HiddenGamesFamicom));
             configLines.Add(string.Format("HiddenGamesSnes={0}", HiddenGamesSnes));

--- a/CustomBorderManager.Designer.cs
+++ b/CustomBorderManager.Designer.cs
@@ -1,0 +1,261 @@
+﻿namespace com.clusterrr.hakchi_gui
+{
+    partial class CustomBorderManager
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.listViewBorders = new System.Windows.Forms.ListView();
+            this.gameName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.label5 = new System.Windows.Forms.Label();
+            this.groupBoxOptions = new System.Windows.Forms.GroupBox();
+            this.pictureBoxArt = new System.Windows.Forms.PictureBox();
+            this.textBoxName = new System.Windows.Forms.TextBox();
+            this.labelName = new System.Windows.Forms.Label();
+            this.buttonDelete = new System.Windows.Forms.Button();
+            this.buttonAdd = new System.Windows.Forms.Button();
+            this.buttonSync = new System.Windows.Forms.Button();
+            this.groupBoxDefaultBorders = new System.Windows.Forms.GroupBox();
+            this.checkedListBoxDefaultBorders = new System.Windows.Forms.CheckedListBox();
+            this.openFileDialogZipBorder = new System.Windows.Forms.OpenFileDialog();
+            this.progressBarSync = new System.Windows.Forms.ProgressBar();
+            this.labelSyncing = new System.Windows.Forms.Label();
+            this.buttonUninstall = new System.Windows.Forms.Button();
+            this.groupBoxOptions.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxArt)).BeginInit();
+            this.groupBoxDefaultBorders.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // listViewBorders
+            // 
+            this.listViewBorders.CheckBoxes = true;
+            this.listViewBorders.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.gameName});
+            this.listViewBorders.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            this.listViewBorders.HideSelection = false;
+            this.listViewBorders.Location = new System.Drawing.Point(12, 25);
+            this.listViewBorders.Name = "listViewBorders";
+            this.listViewBorders.Size = new System.Drawing.Size(282, 269);
+            this.listViewBorders.TabIndex = 8;
+            this.listViewBorders.UseCompatibleStateImageBehavior = false;
+            this.listViewBorders.View = System.Windows.Forms.View.Details;
+            this.listViewBorders.SelectedIndexChanged += new System.EventHandler(this.listViewBorders_SelectedIndexChanged);
+            this.listViewBorders.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listViewBorders_KeyDown);
+            // 
+            // gameName
+            // 
+            this.gameName.Text = "Game name";
+            this.gameName.Width = 253;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.label5.Location = new System.Drawing.Point(12, 9);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(78, 13);
+            this.label5.TabIndex = 9;
+            this.label5.Text = "Select borders:";
+            // 
+            // groupBoxOptions
+            // 
+            this.groupBoxOptions.Controls.Add(this.pictureBoxArt);
+            this.groupBoxOptions.Controls.Add(this.textBoxName);
+            this.groupBoxOptions.Controls.Add(this.labelName);
+            this.groupBoxOptions.Location = new System.Drawing.Point(300, 9);
+            this.groupBoxOptions.Name = "groupBoxOptions";
+            this.groupBoxOptions.Size = new System.Drawing.Size(293, 285);
+            this.groupBoxOptions.TabIndex = 10;
+            this.groupBoxOptions.TabStop = false;
+            this.groupBoxOptions.Text = "Border options";
+            // 
+            // pictureBoxArt
+            // 
+            this.pictureBoxArt.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.pictureBoxArt.Location = new System.Drawing.Point(6, 70);
+            this.pictureBoxArt.Name = "pictureBoxArt";
+            this.pictureBoxArt.Size = new System.Drawing.Size(281, 204);
+            this.pictureBoxArt.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.pictureBoxArt.TabIndex = 12;
+            this.pictureBoxArt.TabStop = false;
+            // 
+            // textBoxName
+            // 
+            this.textBoxName.Enabled = false;
+            this.textBoxName.Location = new System.Drawing.Point(59, 44);
+            this.textBoxName.Name = "textBoxName";
+            this.textBoxName.Size = new System.Drawing.Size(216, 20);
+            this.textBoxName.TabIndex = 2;
+            // 
+            // labelName
+            // 
+            this.labelName.AutoSize = true;
+            this.labelName.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.labelName.Location = new System.Drawing.Point(15, 47);
+            this.labelName.Name = "labelName";
+            this.labelName.Size = new System.Drawing.Size(38, 13);
+            this.labelName.TabIndex = 1;
+            this.labelName.Text = "Name:";
+            // 
+            // buttonDelete
+            // 
+            this.buttonDelete.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.buttonDelete.Location = new System.Drawing.Point(119, 321);
+            this.buttonDelete.Name = "buttonDelete";
+            this.buttonDelete.Size = new System.Drawing.Size(125, 23);
+            this.buttonDelete.TabIndex = 12;
+            this.buttonDelete.Text = "Delete selected";
+            this.buttonDelete.UseVisualStyleBackColor = true;
+            this.buttonDelete.Click += new System.EventHandler(this.buttonDelete_Click);
+            // 
+            // buttonAdd
+            // 
+            this.buttonAdd.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.buttonAdd.Location = new System.Drawing.Point(12, 321);
+            this.buttonAdd.Name = "buttonAdd";
+            this.buttonAdd.Size = new System.Drawing.Size(103, 23);
+            this.buttonAdd.TabIndex = 11;
+            this.buttonAdd.Text = "Add";
+            this.buttonAdd.UseVisualStyleBackColor = true;
+            this.buttonAdd.Click += new System.EventHandler(this.buttonAdd_Click);
+            // 
+            // buttonSync
+            // 
+            this.buttonSync.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.buttonSync.Location = new System.Drawing.Point(250, 321);
+            this.buttonSync.Name = "buttonSync";
+            this.buttonSync.Size = new System.Drawing.Size(103, 23);
+            this.buttonSync.TabIndex = 13;
+            this.buttonSync.Text = "Sync";
+            this.buttonSync.UseVisualStyleBackColor = true;
+            this.buttonSync.Click += new System.EventHandler(this.buttonSync_Click);
+            // 
+            // groupBoxDefaultBorders
+            // 
+            this.groupBoxDefaultBorders.Controls.Add(this.checkedListBoxDefaultBorders);
+            this.groupBoxDefaultBorders.Location = new System.Drawing.Point(300, 9);
+            this.groupBoxDefaultBorders.Name = "groupBoxDefaultBorders";
+            this.groupBoxDefaultBorders.Size = new System.Drawing.Size(293, 285);
+            this.groupBoxDefaultBorders.TabIndex = 15;
+            this.groupBoxDefaultBorders.TabStop = false;
+            this.groupBoxDefaultBorders.Text = "You can hide some default borders";
+            this.groupBoxDefaultBorders.Visible = false;
+            // 
+            // checkedListBoxDefaultBorders
+            // 
+            this.checkedListBoxDefaultBorders.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.checkedListBoxDefaultBorders.FormattingEnabled = true;
+            this.checkedListBoxDefaultBorders.Location = new System.Drawing.Point(5, 39);
+            this.checkedListBoxDefaultBorders.Name = "checkedListBoxDefaultBorders";
+            this.checkedListBoxDefaultBorders.Size = new System.Drawing.Size(282, 229);
+            this.checkedListBoxDefaultBorders.TabIndex = 4;
+            // 
+            // openFileDialogZipBorder
+            // 
+            this.openFileDialogZipBorder.DefaultExt = "zip";
+            this.openFileDialogZipBorder.Filter = "Fichiers zip|*.zip";
+            this.openFileDialogZipBorder.Multiselect = true;
+            // 
+            // progressBarSync
+            // 
+            this.progressBarSync.Location = new System.Drawing.Point(359, 321);
+            this.progressBarSync.Name = "progressBarSync";
+            this.progressBarSync.Size = new System.Drawing.Size(234, 23);
+            this.progressBarSync.TabIndex = 16;
+            this.progressBarSync.Visible = false;
+            // 
+            // labelSyncing
+            // 
+            this.labelSyncing.AutoSize = true;
+            this.labelSyncing.Location = new System.Drawing.Point(356, 300);
+            this.labelSyncing.Name = "labelSyncing";
+            this.labelSyncing.Size = new System.Drawing.Size(0, 13);
+            this.labelSyncing.TabIndex = 17;
+            this.labelSyncing.Visible = false;
+            // 
+            // buttonUninstall
+            // 
+            this.buttonUninstall.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.buttonUninstall.Location = new System.Drawing.Point(490, 295);
+            this.buttonUninstall.Name = "buttonUninstall";
+            this.buttonUninstall.Size = new System.Drawing.Size(103, 23);
+            this.buttonUninstall.TabIndex = 18;
+            this.buttonUninstall.Text = "Uninstall";
+            this.buttonUninstall.UseVisualStyleBackColor = true;
+            this.buttonUninstall.Click += new System.EventHandler(this.buttonUninstall_Click);
+            // 
+            // CustomBorderManager
+            // 
+            this.AllowDrop = true;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(608, 356);
+            this.Controls.Add(this.buttonUninstall);
+            this.Controls.Add(this.labelSyncing);
+            this.Controls.Add(this.progressBarSync);
+            this.Controls.Add(this.groupBoxDefaultBorders);
+            this.Controls.Add(this.groupBoxOptions);
+            this.Controls.Add(this.buttonSync);
+            this.Controls.Add(this.buttonDelete);
+            this.Controls.Add(this.buttonAdd);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.listViewBorders);
+            this.Name = "CustomBorderManager";
+            this.Text = "CustomBorderManager";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.CustomBorderManager_FormClosing);
+            this.DragDrop += new System.Windows.Forms.DragEventHandler(this.CustomBorderManager_DragDrop);
+            this.DragEnter += new System.Windows.Forms.DragEventHandler(this.CustomBorderManager_DragEnter);
+            this.groupBoxOptions.ResumeLayout(false);
+            this.groupBoxOptions.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxArt)).EndInit();
+            this.groupBoxDefaultBorders.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        internal System.Windows.Forms.ListView listViewBorders;
+        private System.Windows.Forms.ColumnHeader gameName;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.GroupBox groupBoxOptions;
+        private System.Windows.Forms.PictureBox pictureBoxArt;
+        private System.Windows.Forms.TextBox textBoxName;
+        private System.Windows.Forms.Label labelName;
+        private System.Windows.Forms.Button buttonDelete;
+        private System.Windows.Forms.Button buttonAdd;
+        private System.Windows.Forms.Button buttonSync;
+        private System.Windows.Forms.GroupBox groupBoxDefaultBorders;
+        protected internal System.Windows.Forms.CheckedListBox checkedListBoxDefaultBorders;
+        private System.Windows.Forms.OpenFileDialog openFileDialogZipBorder;
+        private System.Windows.Forms.ProgressBar progressBarSync;
+        private System.Windows.Forms.Label labelSyncing;
+        private System.Windows.Forms.Button buttonUninstall;
+    }
+}

--- a/CustomBorderManager.cs
+++ b/CustomBorderManager.cs
@@ -238,7 +238,7 @@ namespace com.clusterrr.hakchi_gui
 
         private void buttonSync_Click(object sender, EventArgs e)
         {
-            const string src_backgroundPath = "/usr/share/backgrounds";
+            const string src_backgroundPath = "/var/lib/hakchi/squashfs/usr/share/backgrounds";
             const string dest_backgroundPath = "/var/lib/hakchi/rootfs/usr/share/backgrounds";
             var clovershell = MainForm.Clovershell;
             string bgDirectory = BorderElement.BackgroundsDirectory;
@@ -266,7 +266,7 @@ namespace com.clusterrr.hakchi_gui
                 this.Enabled = false;
                 try
                 {
-                    labelSyncing.Text = "Deleting a file";
+                    /*labelSyncing.Text = "Deleting a file";
                     labelSyncing.Refresh();
                     progressBarSync.Value = 10;
                     progressBarSync.Refresh();
@@ -277,7 +277,7 @@ namespace com.clusterrr.hakchi_gui
                     labelSyncing.Refresh();
                     progressBarSync.Value = 20;
                     progressBarSync.Refresh();
-                    clovershell.ExecuteSimple("reboot", 1000);
+                    clovershell.ExecuteSimple("reboot", 3000);
                     Thread.Sleep(2000);
                     labelSyncing.Text = "Waiting reboot...";
                     labelSyncing.Refresh();
@@ -288,14 +288,14 @@ namespace com.clusterrr.hakchi_gui
                         Debug.WriteLine("Wait reboot");
                         Thread.Sleep(2000);
                     }
-
+                    */
                     labelSyncing.Text = "Creating directory...";
                     labelSyncing.Refresh();
-                    progressBarSync.Value = 40;
+                    progressBarSync.Value = 10;
                     progressBarSync.Refresh();
                     string command = $"src=\"{src_backgroundPath}\" && " +
                                     $"dst=\"{dest_backgroundPath}\" && " +
-                                    $"rm -rf \"$dst\" && " +
+                                    $"rm -rf \"$dst\" && " + 
                                     $"mkdir -p \"$dst\"";
                     clovershell.ExecuteSimple(command, 10000, true);
 
@@ -314,7 +314,7 @@ namespace com.clusterrr.hakchi_gui
 
                     labelSyncing.Text = "Uploading user borders...";
                     labelSyncing.Refresh();
-                    progressBarSync.Value = 50;
+                    progressBarSync.Value = 20;
                     progressBarSync.Refresh();
 
                     using (var bordersTar = new TarStream(tempBordersDirectory))
@@ -334,7 +334,7 @@ namespace com.clusterrr.hakchi_gui
                     string move_cmd = $"mv {dest_backgroundPath}/p8173_ownbgs /etc/preinit.d/";
                     clovershell.ExecuteSimple(move_cmd, 3000, true);
 
-                    labelSyncing.Text = "Copying default borders...";
+                    labelSyncing.Text = "Managing default borders...";
                     labelSyncing.Refresh();
                     progressBarSync.Value = 80;
                     progressBarSync.Refresh();
@@ -347,8 +347,8 @@ namespace com.clusterrr.hakchi_gui
                         foreach (string bordername in selected)
                         {
                             string cmd = $"src=\"{src_backgroundPath}/{bordername}\" && " +
-                                            $"dst=\"{dest_backgroundPath}/\" && " +
-                                            $"mkdir -p \"$dst\" && cp -R \"$src\" \"$dst\"";
+                                            $"dst=\"{dest_backgroundPath}/{bordername}\" && " +
+                                            $"ln -s \"$src\" \"$dst\"";
                             clovershell.ExecuteSimple(cmd, 10000, true);
                         }
                     }

--- a/CustomBorderManager.cs
+++ b/CustomBorderManager.cs
@@ -1,0 +1,501 @@
+﻿using com.clusterrr.hakchi_gui.Apps;
+using com.clusterrr.hakchi_gui.Properties;
+using com.clusterrr.util;
+using SevenZip;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace com.clusterrr.hakchi_gui
+{
+    public partial class CustomBorderManager : Form
+    {
+
+        static DefaultBorder[] defaultBorders = new DefaultBorder[] {
+            new DefaultBorder { Name = "01_ambient"},
+            new DefaultBorder { Name = "02_wire"},
+            new DefaultBorder { Name = "03_crystal"},
+            new DefaultBorder { Name = "04_dot"},
+            new DefaultBorder { Name = "05_mosaic"},
+            new DefaultBorder { Name = "06_dot2"},
+            new DefaultBorder { Name = "07_wood"},
+            new DefaultBorder { Name = "08_space"},
+            new DefaultBorder { Name = "09_speaker"},
+            new DefaultBorder { Name = "10_curtain"},
+            new DefaultBorder { Name = "11_midnight"}
+        };
+
+        public CustomBorderManager()
+        {
+            InitializeComponent();
+
+            var selected = ConfigIni.SelectedBorders.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+            LoadHidden();
+            LoadBorders();
+
+        }
+
+        public void LoadBorders()
+        {
+            Debug.WriteLine("Loading borders");
+            var selected = ConfigIni.SelectedBorders.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            Directory.CreateDirectory(BorderElement.BackgroundsDirectory);
+            var borderDirs = Directory.GetDirectories(BorderElement.BackgroundsDirectory);
+            var borders = new List<BorderElement>();
+            foreach (var borderDir in borderDirs)
+            {
+                try
+                {
+                    // Removing empty directories without errors
+                    try
+                    {
+                        var border = BorderElement.FromDirectory(borderDir);
+                        borders.Add((BorderElement)border);
+                    }
+                    catch (FileNotFoundException ex) // Remove bad directories if any
+                    {
+                        Debug.WriteLine(ex.Message + ex.StackTrace);
+                        Directory.Delete(borderDir, true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex.Message + ex.StackTrace);
+                    MessageBox.Show(this, ex.Message, Resources.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    continue;
+                }
+            }
+
+            var bordersSorted = borders.OrderBy(o => o.Name);
+            listViewBorders.Items.Clear();
+            var listViewItem = new ListViewItem("Default borders");// Resources.Default30games);
+            listViewItem.Tag = "default";
+            listViewItem.Checked = selected.Contains("default");
+            listViewBorders.Items.Add(listViewItem);
+            foreach (var border in bordersSorted)
+            {
+                listViewItem = new ListViewItem(border.Name);
+                listViewItem.Tag = border;
+                listViewItem.Checked = selected.Contains(border.Name);
+                listViewBorders.Items.Add(listViewItem);
+            }
+            /*
+            RecalculateSelectedGames();*/
+            ShowSelected();
+        }
+
+        private List<string> generateFileList(string base_name)
+        {
+            List<string> lfiles = new List<string>();
+            lfiles.Add(base_name + "_4_3.png");
+            lfiles.Add(base_name + "_4_3_options.txt");
+            lfiles.Add(base_name + "_4_3_preview.png");
+            lfiles.Add(base_name + "_pixel_perfect.png");
+            lfiles.Add(base_name + "_pixel_perfect_options.txt");
+            lfiles.Add(base_name + "_pixel_perfect_preview.png");
+            lfiles.Add(base_name + "_thumbnail.png");
+            return lfiles;
+        }
+
+        private void AddBorderZip(string[] files)
+        {
+            foreach (var file in files)
+            {
+                var ext = Path.GetExtension(file).ToLower();
+                var basename = Path.GetFileNameWithoutExtension(file);
+                if (ext == ".7z" || ext == ".zip" || ext == ".rar")
+                {
+                    SevenZipExtractor.SetLibraryPath(Path.Combine(Program.BaseDirectoryInternal, IntPtr.Size == 8 ? @"tools\7z64.dll" : @"tools\7z.dll"));
+                    using (var szExtractor = new SevenZipExtractor(file))
+                    {
+                        szExtractor.PreserveDirectoryStructure = false;
+                        var filesInArchive = new List<string>();
+                        var gameFilesInArchive = new List<string>();
+                        List<string> lfiles = generateFileList(basename);
+                        int lcount = 0;
+                        foreach (var f in szExtractor.ArchiveFileNames)
+                        {
+                            if (lfiles.Contains(f))
+                                lcount++;
+                            else
+                            {
+                                foreach (var ff in lfiles)
+                                {
+                                    if (f.EndsWith(ff))
+                                        lcount++;
+                                }
+                            }
+                            filesInArchive.Add(f);
+                        }
+                        if (lcount == lfiles.Count)
+                        {
+                            string tmp = Path.Combine(BorderElement.BackgroundsDirectory, basename);
+                            Directory.CreateDirectory(tmp);
+                            szExtractor.ExtractArchive(tmp);
+
+                            BorderElement border = new BorderElement(tmp);
+                            bool found = false;
+                            foreach (var i in listViewBorders.Items)
+                            {
+                                if (((ListViewItem)(i)).Text == border.Name)
+                                    found = true;
+                            }
+                            if (!found)
+                            {
+                                ListViewItem listViewItem = new ListViewItem(border.Name);
+                                listViewItem.Tag = border;
+                                listViewItem.Checked = true;
+                                listViewBorders.Items.Add(listViewItem);
+                            }
+                        }
+                    }
+
+                }
+            }
+        }
+
+        private void buttonAdd_Click(object sender, EventArgs e)
+        {
+            if (openFileDialogZipBorder.ShowDialog() == DialogResult.OK)
+            {
+                var files = openFileDialogZipBorder.FileNames;
+                if (files == null) return;
+
+                AddBorderZip(files);
+            }
+        }
+
+        private void deleteBorder()
+        {
+            if (MessageBox.Show(this, "Delete border", Resources.AreYouSure, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == System.Windows.Forms.DialogResult.Yes)
+            {
+                if (listViewBorders.SelectedItems.Count > 0)
+                {
+                    foreach (ListViewItem item in listViewBorders.SelectedItems)
+                    {
+                        if (item.Tag is BorderElement)
+                        {
+                            try
+                            {
+                                Directory.Delete(((BorderElement)(item.Tag)).Path, true);
+                                listViewBorders.Items.Remove(item);
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.WriteLine("delete process failed: {0}", ex.Message);
+                            }
+                        }
+                        //MessageBox.Show(this, Resources.Done, Resources.Wow, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    }
+                }
+            }
+        }
+
+
+        private void buttonDelete_Click(object sender, EventArgs e)
+        {
+            deleteBorder();
+        }
+
+        public static void CopyAll(DirectoryInfo source, DirectoryInfo target)
+        {
+            if (source.FullName.ToLower() == target.FullName.ToLower())
+            {
+                return;
+            }
+
+            // Check if the target directory exists, if not, create it.
+            if (Directory.Exists(target.FullName) == false)
+            {
+                Directory.CreateDirectory(target.FullName);
+            }
+
+            // Copy each file into it's new directory.
+            foreach (FileInfo fi in source.GetFiles())
+            {
+                Debug.Write("Copying " + target.FullName + "/" + fi.Name);
+                fi.CopyTo(Path.Combine(target.ToString(), fi.Name), true);
+            }
+
+            // Copy each subdirectory using recursion.
+            foreach (DirectoryInfo diSourceSubDir in source.GetDirectories())
+            {
+                DirectoryInfo nextTargetSubDir =
+                    target.CreateSubdirectory(diSourceSubDir.Name);
+                CopyAll(diSourceSubDir, nextTargetSubDir);
+            }
+        }
+
+
+        private void buttonSync_Click(object sender, EventArgs e)
+        {
+            const string src_backgroundPath = "/usr/share/backgrounds";
+            const string dest_backgroundPath = "/var/lib/hakchi/rootfs/usr/share/backgrounds";
+            var clovershell = MainForm.Clovershell;
+            string bgDirectory = BorderElement.BackgroundsDirectory;
+            SaveSelectedBorders();
+            ConfigIni.Save();
+            string baseDirectoryInternal = Program.BaseDirectoryInternal;
+            string tempDirectory;
+#if DEBUG
+            tempDirectory = Path.Combine(baseDirectoryInternal, "temp");
+#else
+            tempDirectory = Path.Combine(Path.GetTempPath(), "hakchi-temp");
+#endif
+            string tempBordersDirectory = Path.Combine(tempDirectory, "borders");
+            Directory.CreateDirectory(tempDirectory);
+            Directory.CreateDirectory(tempBordersDirectory);
+            labelSyncing.Text = "Making sync";
+            progressBarSync.Value = 0;
+            labelSyncing.Visible = true;
+            progressBarSync.Visible = true;
+            labelSyncing.Refresh();
+            progressBarSync.Refresh();
+
+            if (clovershell.IsOnline)
+            {
+                this.Enabled = false;
+                try
+                {
+                    labelSyncing.Text = "Deleting a file";
+                    labelSyncing.Refresh();
+                    progressBarSync.Value = 10;
+                    progressBarSync.Refresh();
+                    string del_cmd = $"rm /etc/preinit.d/p8173_ownbgs";
+                    clovershell.ExecuteSimple(del_cmd, 3000);
+                    Thread.Sleep(1000);
+                    labelSyncing.Text = "Reboot...";
+                    labelSyncing.Refresh();
+                    progressBarSync.Value = 20;
+                    progressBarSync.Refresh();
+                    clovershell.ExecuteSimple("reboot", 1000);
+                    Thread.Sleep(2000);
+                    labelSyncing.Text = "Waiting reboot...";
+                    labelSyncing.Refresh();
+                    progressBarSync.Value = 30;
+                    progressBarSync.Refresh();
+                    while (!(clovershell.IsOnline))
+                    {
+                        Debug.WriteLine("Wait reboot");
+                        Thread.Sleep(2000);
+                    }
+
+                    labelSyncing.Text = "Creating directory...";
+                    labelSyncing.Refresh();
+                    progressBarSync.Value = 40;
+                    progressBarSync.Refresh();
+                    string command = $"src=\"{src_backgroundPath}\" && " +
+                                    $"dst=\"{dest_backgroundPath}\" && " +
+                                    $"rm -rf \"$dst\" && " +
+                                    $"mkdir -p \"$dst\"";
+                    clovershell.ExecuteSimple(command, 10000, true);
+
+                    foreach (ListViewItem border in listViewBorders.CheckedItems)
+                    {
+                        if (border.Tag is BorderElement)
+                        {
+                            string repName = (border.Tag as BorderElement).Name;
+                            DirectoryInfo diSource = new DirectoryInfo(bgDirectory + "/" + repName);
+                            DirectoryInfo diTarget = new DirectoryInfo(tempBordersDirectory + "/" + repName);
+                            CopyAll(diSource, diTarget);
+                        }
+                    }
+                    string[] lines = { "overmount /usr/share/backgrounds/", "" };
+                    System.IO.File.WriteAllLines(tempBordersDirectory + "/" + "p8173_ownbgs", lines);
+
+                    labelSyncing.Text = "Uploading user borders...";
+                    labelSyncing.Refresh();
+                    progressBarSync.Value = 50;
+                    progressBarSync.Refresh();
+
+                    using (var bordersTar = new TarStream(tempBordersDirectory))
+                    {
+
+                        if (bordersTar.Length > 0)
+                        {
+                            bordersTar.OnReadProgress += delegate (long pos, long len)
+                            {
+                                Debug.WriteLine("SetProgress(" + pos.ToString() + ", " + len.ToString());
+                            };
+
+                            clovershell.Execute(string.Format("tar -xvC {0}", dest_backgroundPath), bordersTar, null, null, 30000, true);
+                        }
+                    }
+
+                    string move_cmd = $"mv {dest_backgroundPath}/p8173_ownbgs /etc/preinit.d/";
+                    clovershell.ExecuteSimple(move_cmd, 3000, true);
+
+                    labelSyncing.Text = "Copying default borders...";
+                    labelSyncing.Refresh();
+                    progressBarSync.Value = 80;
+                    progressBarSync.Refresh();
+
+                    if (listViewBorders.Items[0].Checked)
+                    {
+                        var selected = new List<string>();
+                        foreach (DefaultBorder border in checkedListBoxDefaultBorders.CheckedItems)
+                            selected.Add(border.Name);
+                        foreach (string bordername in selected)
+                        {
+                            string cmd = $"src=\"{src_backgroundPath}/{bordername}\" && " +
+                                            $"dst=\"{dest_backgroundPath}/\" && " +
+                                            $"mkdir -p \"$dst\" && cp -R \"$src\" \"$dst\"";
+                            clovershell.ExecuteSimple(cmd, 10000, true);
+                        }
+                    }
+                }
+                finally
+                {
+                    try
+                    {
+                        labelSyncing.Text = "Reboot...";
+                        labelSyncing.Refresh();
+                        progressBarSync.Value = 100;
+                        progressBarSync.Refresh();
+                        Directory.Delete(tempDirectory, true);
+                        if (clovershell.IsOnline)
+                            clovershell.ExecuteSimple("reboot", 100);
+
+                    }
+                    catch { }
+                    MessageBox.Show(this, "work is done", "Custom borders", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    this.Enabled = true;
+                    this.Close();
+                }
+            }
+        }
+
+        public void ShowSelected()
+        {
+            object selected = null;
+            var selectedAll = listViewBorders.SelectedItems;
+            if (selectedAll.Count == 1) selected = selectedAll[0].Tag;
+            if (selected == null)
+            {
+                groupBoxDefaultBorders.Visible = false;
+                groupBoxOptions.Visible = true;
+                groupBoxOptions.Enabled = false;
+                textBoxName.Text = "";
+                pictureBoxArt.Image = null;
+            }
+            else if (!(selected is BorderElement))
+            {
+                groupBoxDefaultBorders.Visible = true;
+                groupBoxOptions.Visible = false;
+                groupBoxDefaultBorders.Enabled = listViewBorders.CheckedIndices.Contains(0);
+            }
+            else
+            {
+                var app = selected as BorderElement;
+                groupBoxDefaultBorders.Visible = false;
+                groupBoxOptions.Visible = true;
+                textBoxName.Text = app.Name;
+                if (File.Exists(app.IconPath))
+                    pictureBoxArt.Image = BorderElement.LoadBitmap(app.IconPath);
+                else
+                    pictureBoxArt.Image = null;
+                groupBoxOptions.Enabled = true;
+            }
+        }
+
+        void LoadHidden()
+        {
+            checkedListBoxDefaultBorders.Items.Clear();
+            DefaultBorder[] borders = defaultBorders;
+            foreach (var border in borders.OrderBy(o => o.Name))
+                checkedListBoxDefaultBorders.Items.Add(border, !ConfigIni.HiddenGamesBorders.Contains(border.Name));
+        }
+
+        private void listViewBorders_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ShowSelected();
+        }
+
+        private void SaveSelectedBorders()
+        {
+            var selected = new List<string>();
+            foreach (ListViewItem border in listViewBorders.CheckedItems)
+            {
+                if (border.Tag is BorderElement)
+                    selected.Add((border.Tag as BorderElement).Name);
+                else
+                    selected.Add("default");
+            }
+            ConfigIni.SelectedBorders = string.Join(";", selected.ToArray());
+            selected.Clear();
+
+            foreach (DefaultBorder border in checkedListBoxDefaultBorders.Items)
+                selected.Add(border.Name);
+            foreach (DefaultBorder border in checkedListBoxDefaultBorders.CheckedItems)
+                selected.Remove(border.Name);
+            ConfigIni.HiddenGamesBorders = string.Join(";", selected.ToArray());
+        }
+
+        private void CustomBorderManager_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            SaveSelectedBorders();
+            ConfigIni.Save();
+        }
+
+        private void CustomBorderManager_DragDrop(object sender, DragEventArgs e)
+        {
+            var files = (string[])e.Data.GetData(DataFormats.FileDrop);
+            if (files == null) return;
+            AddBorderZip(files);
+        }
+
+        private void CustomBorderManager_DragEnter(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+                e.Effect = DragDropEffects.Copy;
+        }
+
+        private void buttonUninstall_Click(object sender, EventArgs e)
+        {
+            var clovershell = MainForm.Clovershell;
+            const string dest_backgroundPath = "/var/lib/hakchi/rootfs/usr/share/backgrounds";
+            if (clovershell.IsOnline)
+            {
+                this.Enabled = false;
+                try
+                {
+                    string del_cmd = $"rm /etc/preinit.d/p8173_ownbgs";
+                    clovershell.ExecuteSimple(del_cmd, 3000);
+                    Thread.Sleep(1000);
+                    string command = $"dst=\"{dest_backgroundPath}\" && " +
+                                    $"rm -rf \"$dst/\"";
+                    clovershell.ExecuteSimple(command, 10000, true);
+                }
+                finally
+                {
+                    try
+                    {
+                        if (clovershell.IsOnline)
+                            clovershell.ExecuteSimple("reboot", 100);
+                    }
+                    catch { }
+                    MessageBox.Show(this, "work is done", "Custom borders", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    this.Enabled = true;
+                }
+            }
+        }
+
+        private void listViewBorders_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (listViewBorders.SelectedItems.Count == 0) return;
+            if (e.KeyCode == Keys.Delete && ((listViewBorders.SelectedItems.Count > 1) || (listViewBorders.SelectedItems.Count == 1 && listViewBorders.SelectedItems[0].Tag is BorderElement)))
+            {
+                deleteBorder();
+            }
+        }
+    }
+}

--- a/CustomBorderManager.resx
+++ b/CustomBorderManager.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="openFileDialogZipBorder.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/DefaultBorder.cs
+++ b/DefaultBorder.cs
@@ -1,0 +1,18 @@
+﻿namespace com.clusterrr.hakchi_gui
+{
+    class DefaultBorder
+    {
+        private string name;
+
+        public string Name
+        {
+            get { return name; }
+            set { name = value; }
+        }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+}

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -102,6 +102,8 @@
             this.openTelnetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem8 = new System.Windows.Forms.ToolStripSeparator();
             this.takeScreenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.customBordersManagerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.gitHubPageWithActualReleasesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fAQToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -623,7 +625,9 @@
             this.shellToolStripMenuItem,
             this.openTelnetToolStripMenuItem,
             this.toolStripMenuItem8,
-            this.takeScreenshotToolStripMenuItem});
+            this.takeScreenshotToolStripMenuItem,
+            this.toolStripSeparator1,
+            this.customBordersManagerToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             resources.ApplyResources(this.toolsToolStripMenuItem, "toolsToolStripMenuItem");
             // 
@@ -679,6 +683,17 @@
             this.takeScreenshotToolStripMenuItem.Name = "takeScreenshotToolStripMenuItem";
             resources.ApplyResources(this.takeScreenshotToolStripMenuItem, "takeScreenshotToolStripMenuItem");
             this.takeScreenshotToolStripMenuItem.Click += new System.EventHandler(this.takeScreenshotToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            resources.ApplyResources(this.toolStripSeparator1, "toolStripSeparator1");
+            // 
+            // customBordersManagerToolStripMenuItem
+            // 
+            this.customBordersManagerToolStripMenuItem.Name = "customBordersManagerToolStripMenuItem";
+            resources.ApplyResources(this.customBordersManagerToolStripMenuItem, "customBordersManagerToolStripMenuItem");
+            this.customBordersManagerToolStripMenuItem.Click += new System.EventHandler(this.customBordersManagerToolStripMenuItem_Click);
             // 
             // helpToolStripMenuItem
             // 
@@ -1197,7 +1212,9 @@
         private System.Windows.Forms.ToolStripMenuItem downloadBoxArtForSelectedGamesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem donateToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem dumpNANDCPartitionToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem flashNANDCPartitionToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem flashNANDCPartitionToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripMenuItem customBordersManagerToolStripMenuItem;
     }
 }
 

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -1899,5 +1899,22 @@ namespace com.clusterrr.hakchi_gui
                 ShowSelected();
             }
         }
+
+        private void customBordersManagerToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            switch (ConfigIni.ConsoleType)
+            {
+                case ConsoleType.NES:
+                case ConsoleType.Famicom:
+                    // not available
+                    MessageBox.Show(this, "Change for a SNES Mini to access this ;)", "Not available", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    break;
+                case ConsoleType.SNES:
+                case ConsoleType.SuperFamicom:
+                    var form = new CustomBorderManager();
+                    form.ShowDialog();
+                    break;
+            }
+        }
     }
 }

--- a/MainForm.resx
+++ b/MainForm.resx
@@ -557,6 +557,15 @@
   <data name="takeScreenshotToolStripMenuItem.Text" xml:space="preserve">
     <value>Take screenshot</value>
   </data>
+  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>328, 6</value>
+  </data>
+  <data name="customBordersManagerToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>331, 22</value>
+  </data>
+  <data name="customBordersManagerToolStripMenuItem.Text" xml:space="preserve">
+    <value>Custom Border Manager</value>
+  </data>
   <data name="toolsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>47, 20</value>
   </data>
@@ -3073,6 +3082,18 @@
     <value>takeScreenshotToolStripMenuItem</value>
   </data>
   <data name="&gt;&gt;takeScreenshotToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator1.Name" xml:space="preserve">
+    <value>toolStripSeparator1</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;customBordersManagerToolStripMenuItem.Name" xml:space="preserve">
+    <value>customBordersManagerToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;customBordersManagerToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;helpToolStripMenuItem.Name" xml:space="preserve">

--- a/SaveStateManager.cs
+++ b/SaveStateManager.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -193,8 +194,11 @@ namespace com.clusterrr.hakchi_gui
             {
                 foreach (ListViewItem game in listViewSaves.SelectedItems)
                 {
-                    saveFileDialog.FileName = game.SubItems["colName"].Text + ".clvs";
                     var name = game.SubItems["colName"].Text != null ? game.SubItems["colName"].Text : "save";
+                    string _invalidCharsRegex = "[" + new string(System.IO.Path.GetInvalidFileNameChars()).Replace(@"\", @"\\") + "]";
+                    name = Regex.Replace(name, _invalidCharsRegex, " ");
+                    name = Regex.Replace(name, @"\s+", " ");
+                    saveFileDialog.FileName = name + ".clvs";
                     saveFileDialog.Title = name;
                     if (saveFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                     {

--- a/hakchi_gui.csproj
+++ b/hakchi_gui.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Apps\AppTypeCollection.cs" />
     <Compile Include="Apps\ArcadeGame.cs" />
     <Compile Include="Apps\Atari2600Game.cs" />
+    <Compile Include="Apps\BorderElement.cs" />
     <Compile Include="Apps\ICloverAutofill.cs" />
     <Compile Include="Apps\ISupportsGameGenie.cs" />
     <Compile Include="Apps\Sega32XGame.cs" />
@@ -140,6 +141,13 @@
     <Compile Include="Clovershell\ExecConnection.cs" />
     <Compile Include="Clovershell\ShellConnection.cs" />
     <Compile Include="ConfigIni.cs" />
+    <Compile Include="CustomBorderManager.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="CustomBorderManager.Designer.cs">
+      <DependentUpon>CustomBorderManager.cs</DependentUpon>
+    </Compile>
+    <Compile Include="DefaultBorder.cs" />
     <Compile Include="GameGenie\GameGenieFormatException.cs" />
     <Compile Include="GameGenie\GameGenieNotFoundException.cs" />
     <Compile Include="GameGenie\GameGeniePatcherSnes.cs" />
@@ -619,6 +627,9 @@
     <Compile Include="WorkerForm.Designer.cs">
       <DependentUpon>WorkerForm.cs</DependentUpon>
     </Compile>
+    <EmbeddedResource Include="CustomBorderManager.resx">
+      <DependentUpon>CustomBorderManager.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="FoldersManagerForm.hu-HU.resx">
       <DependentUpon>FoldersManagerForm.cs</DependentUpon>
     </EmbeddedResource>


### PR DESCRIPTION
Hi,
I added a manager for custom borders, available in tools menu.
Near the same behaviour for adding games...
You add zip files "toto.zip" with 7 compressed files prefixed "toto_" inside. Done by "Add" button or drag&drop.
You can delete from disk by "Delete" button or from keyboard.
Check/uncheck to add/remove borders in your SNESmini.

When you sync, first step is a reboot (to delete the file in preinit.d)
then upload your borders, copy original borders and create again the file in preinit.d
and finally reboot.

Uninstall button remove the backgrounds folder and the file in preinit.d (then reboot) on the SNESmini

Some compatible zip files are available here (thanks DarkMime64):
https://www.reddit.com/r/miniSNESmods/comments/753wgd/custom_borders/

+ in SaveStateManager, I remove invalid chars from filename when export savestate (the ':' in SF2T for example)